### PR TITLE
Upgrade to React 16 and publish to npm

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["jason"],
-  "plugins": ["transform-decorators-legacy"]
+  "plugins": ["transform-decorators-legacy", "react-require"]
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-react-widgets
+react-widgets - Forked from 3.4.5
 =============
 
 [![NPM version][npm-image]][npm-url]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
-react-widgets - Forked from 3.4.5
+Lacework fork of react-widgets@3.4.5
 =============
+
+# Releasing
+This could be a single script in package.json, but I figured being explicit is better to catch issues. And we will 
+probably never release another version.
+
+Build for production
+```
+npm run build
+```
+
+Bump the version number. This uses the preid format so we have an obvious link to the source docs and code if neede
+```
+npm version prerelease --preid fork.<next version here> --no-git-tag-version
+```
+
+Publish 
+```
+npm publish --access public --tag latest
+```
 
 [![NPM version][npm-image]][npm-url]
 [![Downloads][downloads-image]][downloads-url]

--- a/README.md
+++ b/README.md
@@ -12,13 +12,16 @@ npm run build
 
 Bump the version number. This uses the preid format so we have an obvious link to the source docs and code if neede
 ```
-npm version prerelease --preid fork.<next version here> --no-git-tag-version
+npm version prerelease --no-git-tag-version
 ```
 
 Publish 
 ```
 npm publish --access public --tag latest
 ```
+
+Commit and push changes to package-lock.json and package.json
+
 
 [![NPM version][npm-image]][npm-url]
 [![Downloads][downloads-image]][downloads-url]

--- a/dist/react-widgets-globalize.js
+++ b/dist/react-widgets-globalize.js
@@ -1,4 +1,4 @@
-/*! (c) 2017 Jason Quense | https://github.com/jquense/react-widgets/blob/master/License.txt */
+/*! (c) 2021 Jason Quense | https://github.com/jquense/react-widgets/blob/master/License.txt */
 /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -43,7 +43,7 @@
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	/*** IMPORTS FROM imports-loader ***/
 	var module = __webpack_require__(1);
@@ -56,18 +56,20 @@
 
 
 
-/***/ },
+/***/ }),
 /* 1 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
 	exports.default = globalizeLocalizers;
 
-	var _react = __webpack_require__(2);
+	var _propTypes = __webpack_require__(2);
 
-	var _configure = __webpack_require__(3);
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _configure = __webpack_require__(5);
 
 	var _configure2 = _interopRequireDefault(_configure);
 
@@ -121,7 +123,7 @@
 	      }
 	    },
 
-	    propType: _react.PropTypes.oneOfType([_react.PropTypes.string, _react.PropTypes.object, _react.PropTypes.func]),
+	    propType: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.object, _propTypes2.default.func]),
 
 	    firstOfWeek: function firstOfWeek(culture) {
 	      var date = new Date();
@@ -145,7 +147,7 @@
 	      default: { maximumFractionDigits: 0 }
 	    },
 
-	    propType: _react.PropTypes.oneOfType([_react.PropTypes.object, _react.PropTypes.func]),
+	    propType: _propTypes2.default.oneOfType([_propTypes2.default.object, _propTypes2.default.func]),
 
 	    // TODO major bump consistent ordering
 	    parse: function parse(value, culture) {
@@ -267,17 +269,124 @@
 	}
 	module.exports = exports['default'];
 
-/***/ },
+/***/ }),
 /* 2 */
-/***/ function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-	module.exports = window.React;
+	/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
 
-/***/ },
+	if (false) {
+	  var ReactIs = require('react-is');
+
+	  // By explicitly using `prop-types` you are opting into new development behavior.
+	  // http://fb.me/prop-types-in-prod
+	  var throwOnDirectAccess = true;
+	  module.exports = require('./factoryWithTypeCheckers')(ReactIs.isElement, throwOnDirectAccess);
+	} else {
+	  // By explicitly using `prop-types` you are opting into new production behavior.
+	  // http://fb.me/prop-types-in-prod
+	  module.exports = __webpack_require__(3)();
+	}
+
+
+/***/ }),
 /* 3 */
-/***/ function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
+
+	/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
+
+	'use strict';
+
+	var ReactPropTypesSecret = __webpack_require__(4);
+
+	function emptyFunction() {}
+	function emptyFunctionWithReset() {}
+	emptyFunctionWithReset.resetWarningCache = emptyFunction;
+
+	module.exports = function() {
+	  function shim(props, propName, componentName, location, propFullName, secret) {
+	    if (secret === ReactPropTypesSecret) {
+	      // It is still safe when called from React.
+	      return;
+	    }
+	    var err = new Error(
+	      'Calling PropTypes validators directly is not supported by the `prop-types` package. ' +
+	      'Use PropTypes.checkPropTypes() to call them. ' +
+	      'Read more at http://fb.me/use-check-prop-types'
+	    );
+	    err.name = 'Invariant Violation';
+	    throw err;
+	  };
+	  shim.isRequired = shim;
+	  function getShim() {
+	    return shim;
+	  };
+	  // Important!
+	  // Keep this list in sync with production version in `./factoryWithTypeCheckers.js`.
+	  var ReactPropTypes = {
+	    array: shim,
+	    bool: shim,
+	    func: shim,
+	    number: shim,
+	    object: shim,
+	    string: shim,
+	    symbol: shim,
+
+	    any: shim,
+	    arrayOf: getShim,
+	    element: shim,
+	    elementType: shim,
+	    instanceOf: getShim,
+	    node: shim,
+	    objectOf: getShim,
+	    oneOf: getShim,
+	    oneOfType: getShim,
+	    shape: getShim,
+	    exact: getShim,
+
+	    checkPropTypes: emptyFunctionWithReset,
+	    resetWarningCache: emptyFunction
+	  };
+
+	  ReactPropTypes.PropTypes = ReactPropTypes;
+
+	  return ReactPropTypes;
+	};
+
+
+/***/ }),
+/* 4 */
+/***/ (function(module, exports) {
+
+	/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
+
+	'use strict';
+
+	var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
+
+	module.exports = ReactPropTypesSecret;
+
+
+/***/ }),
+/* 5 */
+/***/ (function(module, exports) {
 
 	module.exports = window.ReactWidgets;
 
-/***/ }
+/***/ })
 /******/ ]);

--- a/dist/react-widgets-moment.js
+++ b/dist/react-widgets-moment.js
@@ -1,4 +1,4 @@
-/*! (c) 2017 Jason Quense | https://github.com/jquense/react-widgets/blob/master/License.txt */
+/*! (c) 2021 Jason Quense | https://github.com/jquense/react-widgets/blob/master/License.txt */
 /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -43,7 +43,7 @@
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	/*** IMPORTS FROM imports-loader ***/
 	var module = __webpack_require__(1);
@@ -56,9 +56,9 @@
 
 
 
-/***/ },
+/***/ }),
 /* 1 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -131,11 +131,11 @@
 
 	module.exports = exports['default'];
 
-/***/ },
+/***/ }),
 /* 2 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	module.exports = window.ReactWidgets;
 
-/***/ }
+/***/ })
 /******/ ]);

--- a/dist/react-widgets-simple-number.js
+++ b/dist/react-widgets-simple-number.js
@@ -1,4 +1,4 @@
-/*! (c) 2017 Jason Quense | https://github.com/jquense/react-widgets/blob/master/License.txt */
+/*! (c) 2021 Jason Quense | https://github.com/jquense/react-widgets/blob/master/License.txt */
 /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -43,7 +43,7 @@
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	/*** IMPORTS FROM imports-loader ***/
 	var module = __webpack_require__(1);
@@ -56,9 +56,9 @@
 
 
 
-/***/ },
+/***/ }),
 /* 1 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -138,15 +138,15 @@
 	}
 	module.exports = exports['default'];
 
-/***/ },
+/***/ }),
 /* 2 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	module.exports = window.ReactWidgets;
 
-/***/ },
+/***/ }),
 /* 3 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -186,9 +186,9 @@
 
 	};
 
-/***/ },
+/***/ }),
 /* 4 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	'use strict';
 
@@ -391,9 +391,9 @@
 	  return deconstructedFormat;
 	};
 
-/***/ },
+/***/ }),
 /* 5 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	
 	module.exports = formatter;
@@ -652,5 +652,5 @@
 	}
 
 
-/***/ }
+/***/ })
 /******/ ]);

--- a/dist/react-widgets.js
+++ b/dist/react-widgets.js
@@ -7133,7 +7133,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _VIEW, _OPPOSITE_DIRECTION, _MULTIPLIER, _desc, _value, _obj; //values, omit
+	var _VIEW, _OPPOSITE_DIRECTION, _MULTIPLIER, _desc, _value2, _obj; //values, omit
 
 
 	var _propTypes = __webpack_require__(20);
@@ -7217,6 +7217,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
 	function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) {
 	  var desc = {};
@@ -7517,8 +7519,97 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    this.navigate(dir.DOWN, date);
+	  },
+	  changeCurrentDate: function changeCurrentDate(date) {
+	    var currentDate = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : this.props.currentDate;
+
+	    var inRangeDate = this.inRangeValue(date ? new Date(date) : currentDate);
+	    if (_dates2.default.eq(inRangeDate, dateOrNull(currentDate), VIEW_UNIT[this.state.view])) return;
+	    (0, _widgetHelpers.notify)(this.props.onCurrentDateChange, inRangeDate);
+	  },
+	  select: function select(date) {
+	    var view = this.props.initialView,
+	        slideDir = view !== this.state.view || _dates2.default.gt(date, this.state.currentDate) ? 'left' // move down to a the view
+	    : 'right';
+
+	    (0, _widgetHelpers.notify)(this.props.onChange, date);
+
+	    if (this.isValidView(view) && _dates2.default.inRange(date, this.props.min, this.props.max, view)) {
+	      this.focus();
+
+	      this.changeCurrentDate(date);
+
+	      this.setState({
+	        slideDirection: slideDir,
+	        view: view
+	      });
+	    }
+	  },
+	  nextDate: function nextDate(direction) {
+	    var method = direction === dir.LEFT ? 'subtract' : 'add',
+	        view = this.state.view,
+	        unit = view === views.MONTH ? view : views.YEAR,
+	        multi = MULTIPLIER[view] || 1;
+
+	    return _dates2.default[method](this.props.currentDate, 1 * multi, unit);
+	  },
+	  handleKeyDown: function handleKeyDown(e) {
+	    var ctrl = e.ctrlKey,
+	        key = e.key,
+	        direction = ARROWS_TO_DIRECTION[key],
+	        current = this.props.currentDate,
+	        view = this.state.view,
+	        unit = VIEW_UNIT[view],
+	        currentDate = current;
+
+	    if (key === 'Enter') {
+	      e.preventDefault();
+	      return this.change(current);
+	    }
+
+	    if (direction) {
+	      if (ctrl) {
+	        e.preventDefault();
+	        this.navigate(direction);
+	      } else {
+	        if (this.isRtl() && OPPOSITE_DIRECTION[direction]) direction = OPPOSITE_DIRECTION[direction];
+
+	        currentDate = _dates2.default.move(currentDate, this.props.min, this.props.max, view, direction);
+
+	        if (!_dates2.default.eq(current, currentDate, unit)) {
+	          e.preventDefault();
+
+	          if (_dates2.default.gt(currentDate, current, view)) this.navigate(dir.RIGHT, currentDate);else if (_dates2.default.lt(currentDate, current, view)) this.navigate(dir.LEFT, currentDate);else this.changeCurrentDate(currentDate);
+	        }
+	      }
+	    }
+
+	    (0, _widgetHelpers.notify)(this.props.onKeyDown, [e]);
+	  },
+	  _label: function _label() {
+	    var _props2 = this.props,
+	        culture = _props2.culture,
+	        props = _objectWithoutProperties(_props2, ['culture']),
+	        view = this.state.view,
+	        dt = this.props.currentDate;
+
+	    if (view === 'month') return _localizers.date.format(dt, format(props, 'header'), culture);else if (view === 'year') return _localizers.date.format(dt, format(props, 'year'), culture);else if (view === 'decade') return _localizers.date.format(_dates2.default.startOf(dt, 'decade'), format(props, 'decade'), culture);else if (view === 'century') return _localizers.date.format(_dates2.default.startOf(dt, 'century'), format(props, 'century'), culture);
+	  },
+	  inRangeValue: function inRangeValue(_value) {
+	    var value = dateOrNull(_value);
+
+	    if (value === null) return value;
+
+	    return _dates2.default.max(_dates2.default.min(value, this.props.max), this.props.min);
+	  },
+	  isValidView: function isValidView(next) {
+	    var bottom = VIEW_OPTIONS.indexOf(this.props.initialView),
+	        top = VIEW_OPTIONS.indexOf(this.props.finalView),
+	        current = VIEW_OPTIONS.indexOf(next);
+
+	    return current >= bottom && current <= top;
 	  }
-	}, (_applyDecoratedDescriptor(_obj, 'navigate', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'navigate'), _obj), _applyDecoratedDescriptor(_obj, 'change', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'change'), _obj)), _obj));
+	}, (_applyDecoratedDescriptor(_obj, 'navigate', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'navigate'), _obj), _applyDecoratedDescriptor(_obj, 'change', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'change'), _obj), _applyDecoratedDescriptor(_obj, 'select', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'select'), _obj), _applyDecoratedDescriptor(_obj, 'handleKeyDown', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleKeyDown'), _obj)), _obj));
 
 	function dateOrNull(dt) {
 	  if (dt && !isNaN(dt.getTime())) return dt;

--- a/dist/react-widgets.js
+++ b/dist/react-widgets.js
@@ -9283,6 +9283,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; //pick, omit, has
 
+	var _react = __webpack_require__(29);
+
+	var _react2 = _interopRequireDefault(_react);
+
 	var _propTypes = __webpack_require__(20);
 
 	var _propTypes2 = _interopRequireDefault(_propTypes);
@@ -9508,7 +9512,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var focused = this.state.focused;
 
 
-	    return React.createElement(_DateTimePickerInput2.default, {
+	    return _react2.default.createElement(_DateTimePickerInput2.default, {
 	      id: id,
 	      ref: 'valueInput',
 	      role: 'combobox',
@@ -9545,17 +9549,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return null;
 	    }
 
-	    return React.createElement(
+	    return _react2.default.createElement(
 	      'span',
 	      { className: 'rw-select' },
-	      calendar && React.createElement(_Button2.default, {
+	      calendar && _react2.default.createElement(_Button2.default, {
 	        icon: 'calendar',
 	        className: 'rw-btn-calendar',
 	        label: messages.calendarButton,
 	        disabled: !!(disabled || readOnly),
 	        onClick: this._click.bind(null, _constants.datePopups.CALENDAR)
 	      }),
-	      time && React.createElement(_Button2.default, {
+	      time && _react2.default.createElement(_Button2.default, {
 	        icon: 'clock-o',
 	        className: 'rw-btn-time',
 	        label: messages.timeButton,
@@ -9576,7 +9580,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    var calendarProps = _3.default.pickProps(this.props, Calendar);
 
-	    return React.createElement(
+	    return _react2.default.createElement(
 	      _Popup2.default,
 	      {
 	        dropUp: dropUp,
@@ -9584,7 +9588,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        open: open === _constants.datePopups.CALENDAR,
 	        className: 'rw-calendar-popup'
 	      },
-	      React.createElement(Calendar, _extends({}, calendarProps, {
+	      _react2.default.createElement(Calendar, _extends({}, calendarProps, {
 	        ref: 'calPopup',
 	        id: id,
 	        tabIndex: '-1',
@@ -9620,7 +9624,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    var timeListProps = _3.default.pickProps(this.props, _TimeList2.default);
 
-	    return React.createElement(
+	    return _react2.default.createElement(
 	      _Popup2.default,
 	      {
 	        dropUp: dropUp,
@@ -9630,10 +9634,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	          return _this2.refs.timePopup.forceUpdate();
 	        }
 	      },
-	      React.createElement(
+	      _react2.default.createElement(
 	        'div',
 	        null,
-	        React.createElement(_TimeList2.default, _extends({}, timeListProps, {
+	        _react2.default.createElement(_TimeList2.default, _extends({}, timeListProps, {
 	          ref: 'timePopup',
 	          id: id,
 	          format: timeFormat,
@@ -9675,7 +9679,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (calendar) owns += dateListID;
 	    if (time) owns += ' ' + timeListID;
 
-	    return React.createElement(
+	    return _react2.default.createElement(
 	      _Widget2.default,
 	      _extends({}, elementProps, {
 	        open: !!open,

--- a/dist/react-widgets.js
+++ b/dist/react-widgets.js
@@ -1,4 +1,4 @@
-/*! (c) 2017 Jason Quense | https://github.com/jquense/react-widgets/blob/master/License.txt */
+/*! (c) 2021 Jason Quense | https://github.com/jquense/react-widgets/blob/master/License.txt */
 (function webpackUniversalModuleDefinition(root, factory) {
 	if(typeof exports === 'object' && typeof module === 'object')
 		module.exports = factory(require("react"), require("react-dom"));
@@ -8,7 +8,7 @@
 		exports["ReactWidgets"] = factory(require("react"), require("react-dom"));
 	else
 		root["ReactWidgets"] = factory(root["React"], root["ReactDOM"]);
-})(this, function(__WEBPACK_EXTERNAL_MODULE_20__, __WEBPACK_EXTERNAL_MODULE_39__) {
+})(this, function(__WEBPACK_EXTERNAL_MODULE_29__, __WEBPACK_EXTERNAL_MODULE_50__) {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -53,7 +53,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {'use strict';
 
@@ -68,24 +68,24 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 	module.exports = _extends({}, configure, {
-	  DropdownList: __webpack_require__(21),
-	  Combobox: __webpack_require__(63),
-	  Calendar: __webpack_require__(66),
-	  DateTimePicker: __webpack_require__(81),
-	  NumberPicker: __webpack_require__(84),
-	  Multiselect: __webpack_require__(87),
-	  SelectList: __webpack_require__(90),
+	  DropdownList: __webpack_require__(30),
+	  Combobox: __webpack_require__(74),
+	  Calendar: __webpack_require__(77),
+	  DateTimePicker: __webpack_require__(92),
+	  NumberPicker: __webpack_require__(95),
+	  Multiselect: __webpack_require__(98),
+	  SelectList: __webpack_require__(101),
 
 	  utils: {
-	    ReplaceTransitionGroup: __webpack_require__(79),
-	    SlideTransition: __webpack_require__(78)
+	    ReplaceTransitionGroup: __webpack_require__(90),
+	    SlideTransition: __webpack_require__(89)
 	  }
 	});
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
-/***/ },
+/***/ }),
 /* 1 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	// shim for using process in browser
 	var process = module.exports = {};
@@ -257,6 +257,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	process.removeListener = noop;
 	process.removeAllListeners = noop;
 	process.emit = noop;
+	process.prependListener = noop;
+	process.prependOnceListener = noop;
+
+	process.listeners = function (name) { return [] }
 
 	process.binding = function (name) {
 	    throw new Error('process.binding is not supported');
@@ -269,9 +273,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	process.umask = function() { return 0; };
 
 
-/***/ },
+/***/ }),
 /* 2 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -308,9 +312,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 	module.exports = exports['default'];
 
-/***/ },
+/***/ }),
 /* 3 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -325,9 +329,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = { animate: _animate2.default };
 	module.exports = exports['default'];
 
-/***/ },
+/***/ }),
 /* 4 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -438,9 +442,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	module.exports = exports['default'];
 
-/***/ },
+/***/ }),
 /* 5 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	'use strict';
 
@@ -450,9 +454,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return string.replace(rUpper, '-$1').toLowerCase();
 	};
 
-/***/ },
+/***/ }),
 /* 6 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -479,9 +483,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  node.style.cssText += ';' + css;
 	};
 
-/***/ },
+/***/ }),
 /* 7 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	/**
 	 * Copyright 2014-2015, Facebook, Inc.
@@ -497,9 +501,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return camelize(string.replace(msPattern, 'ms-'));
 	};
 
-/***/ },
+/***/ }),
 /* 8 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	"use strict";
 
@@ -511,9 +515,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  });
 	};
 
-/***/ },
+/***/ }),
 /* 9 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	/**
 	 * Copyright 2013-2014, Facebook, Inc.
@@ -530,9 +534,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return hyphenate(string).replace(msPattern, "-ms-");
 	};
 
-/***/ },
+/***/ }),
 /* 10 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -583,9 +587,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  };
 	};
 
-/***/ },
+/***/ }),
 /* 11 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (root, factory) {
 	  if (true) {
@@ -619,9 +623,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  };
 	})
 
-/***/ },
+/***/ }),
 /* 12 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	'use strict';
 
@@ -629,9 +633,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return 'removeProperty' in node.style ? node.style.removeProperty(key) : node.style.removeAttribute(key);
 	};
 
-/***/ },
+/***/ }),
 /* 13 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 	var canUseDOM = __webpack_require__(14);
@@ -650,16 +654,16 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = on;
 
-/***/ },
+/***/ }),
 /* 14 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	'use strict';
 	module.exports = !!(typeof window !== 'undefined' && window.document && window.document.createElement);
 
-/***/ },
+/***/ }),
 /* 15 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 	var canUseDOM = __webpack_require__(14);
@@ -679,9 +683,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = off;
 
-/***/ },
+/***/ }),
 /* 16 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 	var canUseDOM = __webpack_require__(14);
@@ -739,9 +743,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return { end: endEvent, prefix: prefix };
 	}
 
-/***/ },
+/***/ }),
 /* 17 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {'use strict';
 
@@ -755,13 +759,17 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _ = __webpack_require__(19);
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-	var localePropType = _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.func]);
+	var localePropType = _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.func]);
 
 	var REQUIRED_NUMBER_FORMATS = ['default'];
 
@@ -924,17 +932,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
-/***/ },
+/***/ }),
 /* 18 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {/**
-	 * Copyright 2013-2015, Facebook, Inc.
-	 * All rights reserved.
+	 * Copyright (c) 2013-present, Facebook, Inc.
 	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
 	 */
 
 	'use strict';
@@ -982,9 +988,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
-/***/ },
+/***/ }),
 /* 19 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	'use strict';
 
@@ -1109,15 +1115,1155 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }return true;
 	}
 
-/***/ },
+/***/ }),
 /* 20 */
-/***/ function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-	module.exports = __WEBPACK_EXTERNAL_MODULE_20__;
+	/* WEBPACK VAR INJECTION */(function(process) {/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
 
-/***/ },
+	if (process.env.NODE_ENV !== 'production') {
+	  var ReactIs = __webpack_require__(21);
+
+	  // By explicitly using `prop-types` you are opting into new development behavior.
+	  // http://fb.me/prop-types-in-prod
+	  var throwOnDirectAccess = true;
+	  module.exports = __webpack_require__(24)(ReactIs.isElement, throwOnDirectAccess);
+	} else {
+	  // By explicitly using `prop-types` you are opting into new production behavior.
+	  // http://fb.me/prop-types-in-prod
+	  module.exports = __webpack_require__(28)();
+	}
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
+
+/***/ }),
 /* 21 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(process) {'use strict';
+
+	if (process.env.NODE_ENV === 'production') {
+	  module.exports = __webpack_require__(22);
+	} else {
+	  module.exports = __webpack_require__(23);
+	}
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
+
+/***/ }),
+/* 22 */
+/***/ (function(module, exports) {
+
+	/** @license React v16.13.1
+	 * react-is.production.min.js
+	 *
+	 * Copyright (c) Facebook, Inc. and its affiliates.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
+
+	'use strict';var b="function"===typeof Symbol&&Symbol.for,c=b?Symbol.for("react.element"):60103,d=b?Symbol.for("react.portal"):60106,e=b?Symbol.for("react.fragment"):60107,f=b?Symbol.for("react.strict_mode"):60108,g=b?Symbol.for("react.profiler"):60114,h=b?Symbol.for("react.provider"):60109,k=b?Symbol.for("react.context"):60110,l=b?Symbol.for("react.async_mode"):60111,m=b?Symbol.for("react.concurrent_mode"):60111,n=b?Symbol.for("react.forward_ref"):60112,p=b?Symbol.for("react.suspense"):60113,q=b?
+	Symbol.for("react.suspense_list"):60120,r=b?Symbol.for("react.memo"):60115,t=b?Symbol.for("react.lazy"):60116,v=b?Symbol.for("react.block"):60121,w=b?Symbol.for("react.fundamental"):60117,x=b?Symbol.for("react.responder"):60118,y=b?Symbol.for("react.scope"):60119;
+	function z(a){if("object"===typeof a&&null!==a){var u=a.$$typeof;switch(u){case c:switch(a=a.type,a){case l:case m:case e:case g:case f:case p:return a;default:switch(a=a&&a.$$typeof,a){case k:case n:case t:case r:case h:return a;default:return u}}case d:return u}}}function A(a){return z(a)===m}exports.AsyncMode=l;exports.ConcurrentMode=m;exports.ContextConsumer=k;exports.ContextProvider=h;exports.Element=c;exports.ForwardRef=n;exports.Fragment=e;exports.Lazy=t;exports.Memo=r;exports.Portal=d;
+	exports.Profiler=g;exports.StrictMode=f;exports.Suspense=p;exports.isAsyncMode=function(a){return A(a)||z(a)===l};exports.isConcurrentMode=A;exports.isContextConsumer=function(a){return z(a)===k};exports.isContextProvider=function(a){return z(a)===h};exports.isElement=function(a){return"object"===typeof a&&null!==a&&a.$$typeof===c};exports.isForwardRef=function(a){return z(a)===n};exports.isFragment=function(a){return z(a)===e};exports.isLazy=function(a){return z(a)===t};
+	exports.isMemo=function(a){return z(a)===r};exports.isPortal=function(a){return z(a)===d};exports.isProfiler=function(a){return z(a)===g};exports.isStrictMode=function(a){return z(a)===f};exports.isSuspense=function(a){return z(a)===p};
+	exports.isValidElementType=function(a){return"string"===typeof a||"function"===typeof a||a===e||a===m||a===g||a===f||a===p||a===q||"object"===typeof a&&null!==a&&(a.$$typeof===t||a.$$typeof===r||a.$$typeof===h||a.$$typeof===k||a.$$typeof===n||a.$$typeof===w||a.$$typeof===x||a.$$typeof===y||a.$$typeof===v)};exports.typeOf=z;
+
+
+/***/ }),
+/* 23 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(process) {/** @license React v16.13.1
+	 * react-is.development.js
+	 *
+	 * Copyright (c) Facebook, Inc. and its affiliates.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
+
+	'use strict';
+
+
+
+	if (process.env.NODE_ENV !== "production") {
+	  (function() {
+	'use strict';
+
+	// The Symbol used to tag the ReactElement-like types. If there is no native Symbol
+	// nor polyfill, then a plain number is used for performance.
+	var hasSymbol = typeof Symbol === 'function' && Symbol.for;
+	var REACT_ELEMENT_TYPE = hasSymbol ? Symbol.for('react.element') : 0xeac7;
+	var REACT_PORTAL_TYPE = hasSymbol ? Symbol.for('react.portal') : 0xeaca;
+	var REACT_FRAGMENT_TYPE = hasSymbol ? Symbol.for('react.fragment') : 0xeacb;
+	var REACT_STRICT_MODE_TYPE = hasSymbol ? Symbol.for('react.strict_mode') : 0xeacc;
+	var REACT_PROFILER_TYPE = hasSymbol ? Symbol.for('react.profiler') : 0xead2;
+	var REACT_PROVIDER_TYPE = hasSymbol ? Symbol.for('react.provider') : 0xeacd;
+	var REACT_CONTEXT_TYPE = hasSymbol ? Symbol.for('react.context') : 0xeace; // TODO: We don't use AsyncMode or ConcurrentMode anymore. They were temporary
+	// (unstable) APIs that have been removed. Can we remove the symbols?
+
+	var REACT_ASYNC_MODE_TYPE = hasSymbol ? Symbol.for('react.async_mode') : 0xeacf;
+	var REACT_CONCURRENT_MODE_TYPE = hasSymbol ? Symbol.for('react.concurrent_mode') : 0xeacf;
+	var REACT_FORWARD_REF_TYPE = hasSymbol ? Symbol.for('react.forward_ref') : 0xead0;
+	var REACT_SUSPENSE_TYPE = hasSymbol ? Symbol.for('react.suspense') : 0xead1;
+	var REACT_SUSPENSE_LIST_TYPE = hasSymbol ? Symbol.for('react.suspense_list') : 0xead8;
+	var REACT_MEMO_TYPE = hasSymbol ? Symbol.for('react.memo') : 0xead3;
+	var REACT_LAZY_TYPE = hasSymbol ? Symbol.for('react.lazy') : 0xead4;
+	var REACT_BLOCK_TYPE = hasSymbol ? Symbol.for('react.block') : 0xead9;
+	var REACT_FUNDAMENTAL_TYPE = hasSymbol ? Symbol.for('react.fundamental') : 0xead5;
+	var REACT_RESPONDER_TYPE = hasSymbol ? Symbol.for('react.responder') : 0xead6;
+	var REACT_SCOPE_TYPE = hasSymbol ? Symbol.for('react.scope') : 0xead7;
+
+	function isValidElementType(type) {
+	  return typeof type === 'string' || typeof type === 'function' || // Note: its typeof might be other than 'symbol' or 'number' if it's a polyfill.
+	  type === REACT_FRAGMENT_TYPE || type === REACT_CONCURRENT_MODE_TYPE || type === REACT_PROFILER_TYPE || type === REACT_STRICT_MODE_TYPE || type === REACT_SUSPENSE_TYPE || type === REACT_SUSPENSE_LIST_TYPE || typeof type === 'object' && type !== null && (type.$$typeof === REACT_LAZY_TYPE || type.$$typeof === REACT_MEMO_TYPE || type.$$typeof === REACT_PROVIDER_TYPE || type.$$typeof === REACT_CONTEXT_TYPE || type.$$typeof === REACT_FORWARD_REF_TYPE || type.$$typeof === REACT_FUNDAMENTAL_TYPE || type.$$typeof === REACT_RESPONDER_TYPE || type.$$typeof === REACT_SCOPE_TYPE || type.$$typeof === REACT_BLOCK_TYPE);
+	}
+
+	function typeOf(object) {
+	  if (typeof object === 'object' && object !== null) {
+	    var $$typeof = object.$$typeof;
+
+	    switch ($$typeof) {
+	      case REACT_ELEMENT_TYPE:
+	        var type = object.type;
+
+	        switch (type) {
+	          case REACT_ASYNC_MODE_TYPE:
+	          case REACT_CONCURRENT_MODE_TYPE:
+	          case REACT_FRAGMENT_TYPE:
+	          case REACT_PROFILER_TYPE:
+	          case REACT_STRICT_MODE_TYPE:
+	          case REACT_SUSPENSE_TYPE:
+	            return type;
+
+	          default:
+	            var $$typeofType = type && type.$$typeof;
+
+	            switch ($$typeofType) {
+	              case REACT_CONTEXT_TYPE:
+	              case REACT_FORWARD_REF_TYPE:
+	              case REACT_LAZY_TYPE:
+	              case REACT_MEMO_TYPE:
+	              case REACT_PROVIDER_TYPE:
+	                return $$typeofType;
+
+	              default:
+	                return $$typeof;
+	            }
+
+	        }
+
+	      case REACT_PORTAL_TYPE:
+	        return $$typeof;
+	    }
+	  }
+
+	  return undefined;
+	} // AsyncMode is deprecated along with isAsyncMode
+
+	var AsyncMode = REACT_ASYNC_MODE_TYPE;
+	var ConcurrentMode = REACT_CONCURRENT_MODE_TYPE;
+	var ContextConsumer = REACT_CONTEXT_TYPE;
+	var ContextProvider = REACT_PROVIDER_TYPE;
+	var Element = REACT_ELEMENT_TYPE;
+	var ForwardRef = REACT_FORWARD_REF_TYPE;
+	var Fragment = REACT_FRAGMENT_TYPE;
+	var Lazy = REACT_LAZY_TYPE;
+	var Memo = REACT_MEMO_TYPE;
+	var Portal = REACT_PORTAL_TYPE;
+	var Profiler = REACT_PROFILER_TYPE;
+	var StrictMode = REACT_STRICT_MODE_TYPE;
+	var Suspense = REACT_SUSPENSE_TYPE;
+	var hasWarnedAboutDeprecatedIsAsyncMode = false; // AsyncMode should be deprecated
+
+	function isAsyncMode(object) {
+	  {
+	    if (!hasWarnedAboutDeprecatedIsAsyncMode) {
+	      hasWarnedAboutDeprecatedIsAsyncMode = true; // Using console['warn'] to evade Babel and ESLint
+
+	      console['warn']('The ReactIs.isAsyncMode() alias has been deprecated, ' + 'and will be removed in React 17+. Update your code to use ' + 'ReactIs.isConcurrentMode() instead. It has the exact same API.');
+	    }
+	  }
+
+	  return isConcurrentMode(object) || typeOf(object) === REACT_ASYNC_MODE_TYPE;
+	}
+	function isConcurrentMode(object) {
+	  return typeOf(object) === REACT_CONCURRENT_MODE_TYPE;
+	}
+	function isContextConsumer(object) {
+	  return typeOf(object) === REACT_CONTEXT_TYPE;
+	}
+	function isContextProvider(object) {
+	  return typeOf(object) === REACT_PROVIDER_TYPE;
+	}
+	function isElement(object) {
+	  return typeof object === 'object' && object !== null && object.$$typeof === REACT_ELEMENT_TYPE;
+	}
+	function isForwardRef(object) {
+	  return typeOf(object) === REACT_FORWARD_REF_TYPE;
+	}
+	function isFragment(object) {
+	  return typeOf(object) === REACT_FRAGMENT_TYPE;
+	}
+	function isLazy(object) {
+	  return typeOf(object) === REACT_LAZY_TYPE;
+	}
+	function isMemo(object) {
+	  return typeOf(object) === REACT_MEMO_TYPE;
+	}
+	function isPortal(object) {
+	  return typeOf(object) === REACT_PORTAL_TYPE;
+	}
+	function isProfiler(object) {
+	  return typeOf(object) === REACT_PROFILER_TYPE;
+	}
+	function isStrictMode(object) {
+	  return typeOf(object) === REACT_STRICT_MODE_TYPE;
+	}
+	function isSuspense(object) {
+	  return typeOf(object) === REACT_SUSPENSE_TYPE;
+	}
+
+	exports.AsyncMode = AsyncMode;
+	exports.ConcurrentMode = ConcurrentMode;
+	exports.ContextConsumer = ContextConsumer;
+	exports.ContextProvider = ContextProvider;
+	exports.Element = Element;
+	exports.ForwardRef = ForwardRef;
+	exports.Fragment = Fragment;
+	exports.Lazy = Lazy;
+	exports.Memo = Memo;
+	exports.Portal = Portal;
+	exports.Profiler = Profiler;
+	exports.StrictMode = StrictMode;
+	exports.Suspense = Suspense;
+	exports.isAsyncMode = isAsyncMode;
+	exports.isConcurrentMode = isConcurrentMode;
+	exports.isContextConsumer = isContextConsumer;
+	exports.isContextProvider = isContextProvider;
+	exports.isElement = isElement;
+	exports.isForwardRef = isForwardRef;
+	exports.isFragment = isFragment;
+	exports.isLazy = isLazy;
+	exports.isMemo = isMemo;
+	exports.isPortal = isPortal;
+	exports.isProfiler = isProfiler;
+	exports.isStrictMode = isStrictMode;
+	exports.isSuspense = isSuspense;
+	exports.isValidElementType = isValidElementType;
+	exports.typeOf = typeOf;
+	  })();
+	}
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
+
+/***/ }),
+/* 24 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(process) {/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
+
+	'use strict';
+
+	var ReactIs = __webpack_require__(21);
+	var assign = __webpack_require__(25);
+
+	var ReactPropTypesSecret = __webpack_require__(26);
+	var checkPropTypes = __webpack_require__(27);
+
+	var has = Function.call.bind(Object.prototype.hasOwnProperty);
+	var printWarning = function() {};
+
+	if (process.env.NODE_ENV !== 'production') {
+	  printWarning = function(text) {
+	    var message = 'Warning: ' + text;
+	    if (typeof console !== 'undefined') {
+	      console.error(message);
+	    }
+	    try {
+	      // --- Welcome to debugging React ---
+	      // This error was thrown as a convenience so that you can use this stack
+	      // to find the callsite that caused this warning to fire.
+	      throw new Error(message);
+	    } catch (x) {}
+	  };
+	}
+
+	function emptyFunctionThatReturnsNull() {
+	  return null;
+	}
+
+	module.exports = function(isValidElement, throwOnDirectAccess) {
+	  /* global Symbol */
+	  var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+	  var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
+
+	  /**
+	   * Returns the iterator method function contained on the iterable object.
+	   *
+	   * Be sure to invoke the function with the iterable as context:
+	   *
+	   *     var iteratorFn = getIteratorFn(myIterable);
+	   *     if (iteratorFn) {
+	   *       var iterator = iteratorFn.call(myIterable);
+	   *       ...
+	   *     }
+	   *
+	   * @param {?object} maybeIterable
+	   * @return {?function}
+	   */
+	  function getIteratorFn(maybeIterable) {
+	    var iteratorFn = maybeIterable && (ITERATOR_SYMBOL && maybeIterable[ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL]);
+	    if (typeof iteratorFn === 'function') {
+	      return iteratorFn;
+	    }
+	  }
+
+	  /**
+	   * Collection of methods that allow declaration and validation of props that are
+	   * supplied to React components. Example usage:
+	   *
+	   *   var Props = require('ReactPropTypes');
+	   *   var MyArticle = React.createClass({
+	   *     propTypes: {
+	   *       // An optional string prop named "description".
+	   *       description: Props.string,
+	   *
+	   *       // A required enum prop named "category".
+	   *       category: Props.oneOf(['News','Photos']).isRequired,
+	   *
+	   *       // A prop named "dialog" that requires an instance of Dialog.
+	   *       dialog: Props.instanceOf(Dialog).isRequired
+	   *     },
+	   *     render: function() { ... }
+	   *   });
+	   *
+	   * A more formal specification of how these methods are used:
+	   *
+	   *   type := array|bool|func|object|number|string|oneOf([...])|instanceOf(...)
+	   *   decl := ReactPropTypes.{type}(.isRequired)?
+	   *
+	   * Each and every declaration produces a function with the same signature. This
+	   * allows the creation of custom validation functions. For example:
+	   *
+	   *  var MyLink = React.createClass({
+	   *    propTypes: {
+	   *      // An optional string or URI prop named "href".
+	   *      href: function(props, propName, componentName) {
+	   *        var propValue = props[propName];
+	   *        if (propValue != null && typeof propValue !== 'string' &&
+	   *            !(propValue instanceof URI)) {
+	   *          return new Error(
+	   *            'Expected a string or an URI for ' + propName + ' in ' +
+	   *            componentName
+	   *          );
+	   *        }
+	   *      }
+	   *    },
+	   *    render: function() {...}
+	   *  });
+	   *
+	   * @internal
+	   */
+
+	  var ANONYMOUS = '<<anonymous>>';
+
+	  // Important!
+	  // Keep this list in sync with production version in `./factoryWithThrowingShims.js`.
+	  var ReactPropTypes = {
+	    array: createPrimitiveTypeChecker('array'),
+	    bool: createPrimitiveTypeChecker('boolean'),
+	    func: createPrimitiveTypeChecker('function'),
+	    number: createPrimitiveTypeChecker('number'),
+	    object: createPrimitiveTypeChecker('object'),
+	    string: createPrimitiveTypeChecker('string'),
+	    symbol: createPrimitiveTypeChecker('symbol'),
+
+	    any: createAnyTypeChecker(),
+	    arrayOf: createArrayOfTypeChecker,
+	    element: createElementTypeChecker(),
+	    elementType: createElementTypeTypeChecker(),
+	    instanceOf: createInstanceTypeChecker,
+	    node: createNodeChecker(),
+	    objectOf: createObjectOfTypeChecker,
+	    oneOf: createEnumTypeChecker,
+	    oneOfType: createUnionTypeChecker,
+	    shape: createShapeTypeChecker,
+	    exact: createStrictShapeTypeChecker,
+	  };
+
+	  /**
+	   * inlined Object.is polyfill to avoid requiring consumers ship their own
+	   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+	   */
+	  /*eslint-disable no-self-compare*/
+	  function is(x, y) {
+	    // SameValue algorithm
+	    if (x === y) {
+	      // Steps 1-5, 7-10
+	      // Steps 6.b-6.e: +0 != -0
+	      return x !== 0 || 1 / x === 1 / y;
+	    } else {
+	      // Step 6.a: NaN == NaN
+	      return x !== x && y !== y;
+	    }
+	  }
+	  /*eslint-enable no-self-compare*/
+
+	  /**
+	   * We use an Error-like object for backward compatibility as people may call
+	   * PropTypes directly and inspect their output. However, we don't use real
+	   * Errors anymore. We don't inspect their stack anyway, and creating them
+	   * is prohibitively expensive if they are created too often, such as what
+	   * happens in oneOfType() for any type before the one that matched.
+	   */
+	  function PropTypeError(message) {
+	    this.message = message;
+	    this.stack = '';
+	  }
+	  // Make `instanceof Error` still work for returned errors.
+	  PropTypeError.prototype = Error.prototype;
+
+	  function createChainableTypeChecker(validate) {
+	    if (process.env.NODE_ENV !== 'production') {
+	      var manualPropTypeCallCache = {};
+	      var manualPropTypeWarningCount = 0;
+	    }
+	    function checkType(isRequired, props, propName, componentName, location, propFullName, secret) {
+	      componentName = componentName || ANONYMOUS;
+	      propFullName = propFullName || propName;
+
+	      if (secret !== ReactPropTypesSecret) {
+	        if (throwOnDirectAccess) {
+	          // New behavior only for users of `prop-types` package
+	          var err = new Error(
+	            'Calling PropTypes validators directly is not supported by the `prop-types` package. ' +
+	            'Use `PropTypes.checkPropTypes()` to call them. ' +
+	            'Read more at http://fb.me/use-check-prop-types'
+	          );
+	          err.name = 'Invariant Violation';
+	          throw err;
+	        } else if (process.env.NODE_ENV !== 'production' && typeof console !== 'undefined') {
+	          // Old behavior for people using React.PropTypes
+	          var cacheKey = componentName + ':' + propName;
+	          if (
+	            !manualPropTypeCallCache[cacheKey] &&
+	            // Avoid spamming the console because they are often not actionable except for lib authors
+	            manualPropTypeWarningCount < 3
+	          ) {
+	            printWarning(
+	              'You are manually calling a React.PropTypes validation ' +
+	              'function for the `' + propFullName + '` prop on `' + componentName  + '`. This is deprecated ' +
+	              'and will throw in the standalone `prop-types` package. ' +
+	              'You may be seeing this warning due to a third-party PropTypes ' +
+	              'library. See https://fb.me/react-warning-dont-call-proptypes ' + 'for details.'
+	            );
+	            manualPropTypeCallCache[cacheKey] = true;
+	            manualPropTypeWarningCount++;
+	          }
+	        }
+	      }
+	      if (props[propName] == null) {
+	        if (isRequired) {
+	          if (props[propName] === null) {
+	            return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required ' + ('in `' + componentName + '`, but its value is `null`.'));
+	          }
+	          return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required in ' + ('`' + componentName + '`, but its value is `undefined`.'));
+	        }
+	        return null;
+	      } else {
+	        return validate(props, propName, componentName, location, propFullName);
+	      }
+	    }
+
+	    var chainedCheckType = checkType.bind(null, false);
+	    chainedCheckType.isRequired = checkType.bind(null, true);
+
+	    return chainedCheckType;
+	  }
+
+	  function createPrimitiveTypeChecker(expectedType) {
+	    function validate(props, propName, componentName, location, propFullName, secret) {
+	      var propValue = props[propName];
+	      var propType = getPropType(propValue);
+	      if (propType !== expectedType) {
+	        // `propValue` being instance of, say, date/regexp, pass the 'object'
+	        // check, but we can offer a more precise error message here rather than
+	        // 'of type `object`'.
+	        var preciseType = getPreciseType(propValue);
+
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + preciseType + '` supplied to `' + componentName + '`, expected ') + ('`' + expectedType + '`.'));
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createAnyTypeChecker() {
+	    return createChainableTypeChecker(emptyFunctionThatReturnsNull);
+	  }
+
+	  function createArrayOfTypeChecker(typeChecker) {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      if (typeof typeChecker !== 'function') {
+	        return new PropTypeError('Property `' + propFullName + '` of component `' + componentName + '` has invalid PropType notation inside arrayOf.');
+	      }
+	      var propValue = props[propName];
+	      if (!Array.isArray(propValue)) {
+	        var propType = getPropType(propValue);
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected an array.'));
+	      }
+	      for (var i = 0; i < propValue.length; i++) {
+	        var error = typeChecker(propValue, i, componentName, location, propFullName + '[' + i + ']', ReactPropTypesSecret);
+	        if (error instanceof Error) {
+	          return error;
+	        }
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createElementTypeChecker() {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      var propValue = props[propName];
+	      if (!isValidElement(propValue)) {
+	        var propType = getPropType(propValue);
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected a single ReactElement.'));
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createElementTypeTypeChecker() {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      var propValue = props[propName];
+	      if (!ReactIs.isValidElementType(propValue)) {
+	        var propType = getPropType(propValue);
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected a single ReactElement type.'));
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createInstanceTypeChecker(expectedClass) {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      if (!(props[propName] instanceof expectedClass)) {
+	        var expectedClassName = expectedClass.name || ANONYMOUS;
+	        var actualClassName = getClassName(props[propName]);
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + actualClassName + '` supplied to `' + componentName + '`, expected ') + ('instance of `' + expectedClassName + '`.'));
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createEnumTypeChecker(expectedValues) {
+	    if (!Array.isArray(expectedValues)) {
+	      if (process.env.NODE_ENV !== 'production') {
+	        if (arguments.length > 1) {
+	          printWarning(
+	            'Invalid arguments supplied to oneOf, expected an array, got ' + arguments.length + ' arguments. ' +
+	            'A common mistake is to write oneOf(x, y, z) instead of oneOf([x, y, z]).'
+	          );
+	        } else {
+	          printWarning('Invalid argument supplied to oneOf, expected an array.');
+	        }
+	      }
+	      return emptyFunctionThatReturnsNull;
+	    }
+
+	    function validate(props, propName, componentName, location, propFullName) {
+	      var propValue = props[propName];
+	      for (var i = 0; i < expectedValues.length; i++) {
+	        if (is(propValue, expectedValues[i])) {
+	          return null;
+	        }
+	      }
+
+	      var valuesString = JSON.stringify(expectedValues, function replacer(key, value) {
+	        var type = getPreciseType(value);
+	        if (type === 'symbol') {
+	          return String(value);
+	        }
+	        return value;
+	      });
+	      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of value `' + String(propValue) + '` ' + ('supplied to `' + componentName + '`, expected one of ' + valuesString + '.'));
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createObjectOfTypeChecker(typeChecker) {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      if (typeof typeChecker !== 'function') {
+	        return new PropTypeError('Property `' + propFullName + '` of component `' + componentName + '` has invalid PropType notation inside objectOf.');
+	      }
+	      var propValue = props[propName];
+	      var propType = getPropType(propValue);
+	      if (propType !== 'object') {
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected an object.'));
+	      }
+	      for (var key in propValue) {
+	        if (has(propValue, key)) {
+	          var error = typeChecker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);
+	          if (error instanceof Error) {
+	            return error;
+	          }
+	        }
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createUnionTypeChecker(arrayOfTypeCheckers) {
+	    if (!Array.isArray(arrayOfTypeCheckers)) {
+	      process.env.NODE_ENV !== 'production' ? printWarning('Invalid argument supplied to oneOfType, expected an instance of array.') : void 0;
+	      return emptyFunctionThatReturnsNull;
+	    }
+
+	    for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
+	      var checker = arrayOfTypeCheckers[i];
+	      if (typeof checker !== 'function') {
+	        printWarning(
+	          'Invalid argument supplied to oneOfType. Expected an array of check functions, but ' +
+	          'received ' + getPostfixForTypeWarning(checker) + ' at index ' + i + '.'
+	        );
+	        return emptyFunctionThatReturnsNull;
+	      }
+	    }
+
+	    function validate(props, propName, componentName, location, propFullName) {
+	      for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
+	        var checker = arrayOfTypeCheckers[i];
+	        if (checker(props, propName, componentName, location, propFullName, ReactPropTypesSecret) == null) {
+	          return null;
+	        }
+	      }
+
+	      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`.'));
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createNodeChecker() {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      if (!isNode(props[propName])) {
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`, expected a ReactNode.'));
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createShapeTypeChecker(shapeTypes) {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      var propValue = props[propName];
+	      var propType = getPropType(propValue);
+	      if (propType !== 'object') {
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`, expected `object`.'));
+	      }
+	      for (var key in shapeTypes) {
+	        var checker = shapeTypes[key];
+	        if (!checker) {
+	          continue;
+	        }
+	        var error = checker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);
+	        if (error) {
+	          return error;
+	        }
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createStrictShapeTypeChecker(shapeTypes) {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      var propValue = props[propName];
+	      var propType = getPropType(propValue);
+	      if (propType !== 'object') {
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`, expected `object`.'));
+	      }
+	      // We need to check all keys in case some are required but missing from
+	      // props.
+	      var allKeys = assign({}, props[propName], shapeTypes);
+	      for (var key in allKeys) {
+	        var checker = shapeTypes[key];
+	        if (!checker) {
+	          return new PropTypeError(
+	            'Invalid ' + location + ' `' + propFullName + '` key `' + key + '` supplied to `' + componentName + '`.' +
+	            '\nBad object: ' + JSON.stringify(props[propName], null, '  ') +
+	            '\nValid keys: ' +  JSON.stringify(Object.keys(shapeTypes), null, '  ')
+	          );
+	        }
+	        var error = checker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);
+	        if (error) {
+	          return error;
+	        }
+	      }
+	      return null;
+	    }
+
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function isNode(propValue) {
+	    switch (typeof propValue) {
+	      case 'number':
+	      case 'string':
+	      case 'undefined':
+	        return true;
+	      case 'boolean':
+	        return !propValue;
+	      case 'object':
+	        if (Array.isArray(propValue)) {
+	          return propValue.every(isNode);
+	        }
+	        if (propValue === null || isValidElement(propValue)) {
+	          return true;
+	        }
+
+	        var iteratorFn = getIteratorFn(propValue);
+	        if (iteratorFn) {
+	          var iterator = iteratorFn.call(propValue);
+	          var step;
+	          if (iteratorFn !== propValue.entries) {
+	            while (!(step = iterator.next()).done) {
+	              if (!isNode(step.value)) {
+	                return false;
+	              }
+	            }
+	          } else {
+	            // Iterator will provide entry [k,v] tuples rather than values.
+	            while (!(step = iterator.next()).done) {
+	              var entry = step.value;
+	              if (entry) {
+	                if (!isNode(entry[1])) {
+	                  return false;
+	                }
+	              }
+	            }
+	          }
+	        } else {
+	          return false;
+	        }
+
+	        return true;
+	      default:
+	        return false;
+	    }
+	  }
+
+	  function isSymbol(propType, propValue) {
+	    // Native Symbol.
+	    if (propType === 'symbol') {
+	      return true;
+	    }
+
+	    // falsy value can't be a Symbol
+	    if (!propValue) {
+	      return false;
+	    }
+
+	    // 19.4.3.5 Symbol.prototype[@@toStringTag] === 'Symbol'
+	    if (propValue['@@toStringTag'] === 'Symbol') {
+	      return true;
+	    }
+
+	    // Fallback for non-spec compliant Symbols which are polyfilled.
+	    if (typeof Symbol === 'function' && propValue instanceof Symbol) {
+	      return true;
+	    }
+
+	    return false;
+	  }
+
+	  // Equivalent of `typeof` but with special handling for array and regexp.
+	  function getPropType(propValue) {
+	    var propType = typeof propValue;
+	    if (Array.isArray(propValue)) {
+	      return 'array';
+	    }
+	    if (propValue instanceof RegExp) {
+	      // Old webkits (at least until Android 4.0) return 'function' rather than
+	      // 'object' for typeof a RegExp. We'll normalize this here so that /bla/
+	      // passes PropTypes.object.
+	      return 'object';
+	    }
+	    if (isSymbol(propType, propValue)) {
+	      return 'symbol';
+	    }
+	    return propType;
+	  }
+
+	  // This handles more types than `getPropType`. Only used for error messages.
+	  // See `createPrimitiveTypeChecker`.
+	  function getPreciseType(propValue) {
+	    if (typeof propValue === 'undefined' || propValue === null) {
+	      return '' + propValue;
+	    }
+	    var propType = getPropType(propValue);
+	    if (propType === 'object') {
+	      if (propValue instanceof Date) {
+	        return 'date';
+	      } else if (propValue instanceof RegExp) {
+	        return 'regexp';
+	      }
+	    }
+	    return propType;
+	  }
+
+	  // Returns a string that is postfixed to a warning about an invalid type.
+	  // For example, "undefined" or "of type array"
+	  function getPostfixForTypeWarning(value) {
+	    var type = getPreciseType(value);
+	    switch (type) {
+	      case 'array':
+	      case 'object':
+	        return 'an ' + type;
+	      case 'boolean':
+	      case 'date':
+	      case 'regexp':
+	        return 'a ' + type;
+	      default:
+	        return type;
+	    }
+	  }
+
+	  // Returns class name of the object, if any.
+	  function getClassName(propValue) {
+	    if (!propValue.constructor || !propValue.constructor.name) {
+	      return ANONYMOUS;
+	    }
+	    return propValue.constructor.name;
+	  }
+
+	  ReactPropTypes.checkPropTypes = checkPropTypes;
+	  ReactPropTypes.resetWarningCache = checkPropTypes.resetWarningCache;
+	  ReactPropTypes.PropTypes = ReactPropTypes;
+
+	  return ReactPropTypes;
+	};
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
+
+/***/ }),
+/* 25 */
+/***/ (function(module, exports) {
+
+	/*
+	object-assign
+	(c) Sindre Sorhus
+	@license MIT
+	*/
+
+	'use strict';
+	/* eslint-disable no-unused-vars */
+	var getOwnPropertySymbols = Object.getOwnPropertySymbols;
+	var hasOwnProperty = Object.prototype.hasOwnProperty;
+	var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+	function toObject(val) {
+		if (val === null || val === undefined) {
+			throw new TypeError('Object.assign cannot be called with null or undefined');
+		}
+
+		return Object(val);
+	}
+
+	function shouldUseNative() {
+		try {
+			if (!Object.assign) {
+				return false;
+			}
+
+			// Detect buggy property enumeration order in older V8 versions.
+
+			// https://bugs.chromium.org/p/v8/issues/detail?id=4118
+			var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
+			test1[5] = 'de';
+			if (Object.getOwnPropertyNames(test1)[0] === '5') {
+				return false;
+			}
+
+			// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+			var test2 = {};
+			for (var i = 0; i < 10; i++) {
+				test2['_' + String.fromCharCode(i)] = i;
+			}
+			var order2 = Object.getOwnPropertyNames(test2).map(function (n) {
+				return test2[n];
+			});
+			if (order2.join('') !== '0123456789') {
+				return false;
+			}
+
+			// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+			var test3 = {};
+			'abcdefghijklmnopqrst'.split('').forEach(function (letter) {
+				test3[letter] = letter;
+			});
+			if (Object.keys(Object.assign({}, test3)).join('') !==
+					'abcdefghijklmnopqrst') {
+				return false;
+			}
+
+			return true;
+		} catch (err) {
+			// We don't expect any of the above to throw, but better to be safe.
+			return false;
+		}
+	}
+
+	module.exports = shouldUseNative() ? Object.assign : function (target, source) {
+		var from;
+		var to = toObject(target);
+		var symbols;
+
+		for (var s = 1; s < arguments.length; s++) {
+			from = Object(arguments[s]);
+
+			for (var key in from) {
+				if (hasOwnProperty.call(from, key)) {
+					to[key] = from[key];
+				}
+			}
+
+			if (getOwnPropertySymbols) {
+				symbols = getOwnPropertySymbols(from);
+				for (var i = 0; i < symbols.length; i++) {
+					if (propIsEnumerable.call(from, symbols[i])) {
+						to[symbols[i]] = from[symbols[i]];
+					}
+				}
+			}
+		}
+
+		return to;
+	};
+
+
+/***/ }),
+/* 26 */
+/***/ (function(module, exports) {
+
+	/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
+
+	'use strict';
+
+	var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
+
+	module.exports = ReactPropTypesSecret;
+
+
+/***/ }),
+/* 27 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(process) {/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
+
+	'use strict';
+
+	var printWarning = function() {};
+
+	if (process.env.NODE_ENV !== 'production') {
+	  var ReactPropTypesSecret = __webpack_require__(26);
+	  var loggedTypeFailures = {};
+	  var has = Function.call.bind(Object.prototype.hasOwnProperty);
+
+	  printWarning = function(text) {
+	    var message = 'Warning: ' + text;
+	    if (typeof console !== 'undefined') {
+	      console.error(message);
+	    }
+	    try {
+	      // --- Welcome to debugging React ---
+	      // This error was thrown as a convenience so that you can use this stack
+	      // to find the callsite that caused this warning to fire.
+	      throw new Error(message);
+	    } catch (x) {}
+	  };
+	}
+
+	/**
+	 * Assert that the values match with the type specs.
+	 * Error messages are memorized and will only be shown once.
+	 *
+	 * @param {object} typeSpecs Map of name to a ReactPropType
+	 * @param {object} values Runtime values that need to be type-checked
+	 * @param {string} location e.g. "prop", "context", "child context"
+	 * @param {string} componentName Name of the component for error messages.
+	 * @param {?Function} getStack Returns the component stack.
+	 * @private
+	 */
+	function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
+	  if (process.env.NODE_ENV !== 'production') {
+	    for (var typeSpecName in typeSpecs) {
+	      if (has(typeSpecs, typeSpecName)) {
+	        var error;
+	        // Prop type validation may throw. In case they do, we don't want to
+	        // fail the render phase where it didn't fail before. So we log it.
+	        // After these have been cleaned up, we'll let them throw.
+	        try {
+	          // This is intentionally an invariant that gets caught. It's the same
+	          // behavior as without this statement except with a better message.
+	          if (typeof typeSpecs[typeSpecName] !== 'function') {
+	            var err = Error(
+	              (componentName || 'React class') + ': ' + location + ' type `' + typeSpecName + '` is invalid; ' +
+	              'it must be a function, usually from the `prop-types` package, but received `' + typeof typeSpecs[typeSpecName] + '`.'
+	            );
+	            err.name = 'Invariant Violation';
+	            throw err;
+	          }
+	          error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
+	        } catch (ex) {
+	          error = ex;
+	        }
+	        if (error && !(error instanceof Error)) {
+	          printWarning(
+	            (componentName || 'React class') + ': type specification of ' +
+	            location + ' `' + typeSpecName + '` is invalid; the type checker ' +
+	            'function must return `null` or an `Error` but returned a ' + typeof error + '. ' +
+	            'You may have forgotten to pass an argument to the type checker ' +
+	            'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' +
+	            'shape all require an argument).'
+	          );
+	        }
+	        if (error instanceof Error && !(error.message in loggedTypeFailures)) {
+	          // Only monitor this failure once because there tends to be a lot of the
+	          // same error.
+	          loggedTypeFailures[error.message] = true;
+
+	          var stack = getStack ? getStack() : '';
+
+	          printWarning(
+	            'Failed ' + location + ' type: ' + error.message + (stack != null ? stack : '')
+	          );
+	        }
+	      }
+	    }
+	  }
+	}
+
+	/**
+	 * Resets warning cache when testing.
+	 *
+	 * @private
+	 */
+	checkPropTypes.resetWarningCache = function() {
+	  if (process.env.NODE_ENV !== 'production') {
+	    loggedTypeFailures = {};
+	  }
+	}
+
+	module.exports = checkPropTypes;
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
+
+/***/ }),
+/* 28 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
+
+	'use strict';
+
+	var ReactPropTypesSecret = __webpack_require__(26);
+
+	function emptyFunction() {}
+	function emptyFunctionWithReset() {}
+	emptyFunctionWithReset.resetWarningCache = emptyFunction;
+
+	module.exports = function() {
+	  function shim(props, propName, componentName, location, propFullName, secret) {
+	    if (secret === ReactPropTypesSecret) {
+	      // It is still safe when called from React.
+	      return;
+	    }
+	    var err = new Error(
+	      'Calling PropTypes validators directly is not supported by the `prop-types` package. ' +
+	      'Use PropTypes.checkPropTypes() to call them. ' +
+	      'Read more at http://fb.me/use-check-prop-types'
+	    );
+	    err.name = 'Invariant Violation';
+	    throw err;
+	  };
+	  shim.isRequired = shim;
+	  function getShim() {
+	    return shim;
+	  };
+	  // Important!
+	  // Keep this list in sync with production version in `./factoryWithTypeCheckers.js`.
+	  var ReactPropTypes = {
+	    array: shim,
+	    bool: shim,
+	    func: shim,
+	    number: shim,
+	    object: shim,
+	    string: shim,
+	    symbol: shim,
+
+	    any: shim,
+	    arrayOf: getShim,
+	    element: shim,
+	    elementType: shim,
+	    instanceOf: getShim,
+	    node: shim,
+	    objectOf: getShim,
+	    oneOf: getShim,
+	    oneOfType: getShim,
+	    shape: getShim,
+	    exact: getShim,
+
+	    checkPropTypes: emptyFunctionWithReset,
+	    resetWarningCache: emptyFunction
+	  };
+
+	  ReactPropTypes.PropTypes = ReactPropTypes;
+
+	  return ReactPropTypes;
+	};
+
+
+/***/ }),
+/* 29 */
+/***/ (function(module, exports) {
+
+	module.exports = __WEBPACK_EXTERNAL_MODULE_29__;
+
+/***/ }),
+/* 30 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -1127,19 +2273,27 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _activeElement = __webpack_require__(22);
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+	var _activeElement = __webpack_require__(33);
 
 	var _activeElement2 = _interopRequireDefault(_activeElement);
 
-	var _contains = __webpack_require__(24);
+	var _contains = __webpack_require__(35);
 
 	var _contains2 = _interopRequireDefault(_contains);
 
-	var _classnames = __webpack_require__(25);
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
@@ -1147,55 +2301,55 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _Widget = __webpack_require__(26);
+	var _Widget = __webpack_require__(37);
 
 	var _Widget2 = _interopRequireDefault(_Widget);
 
-	var _Input = __webpack_require__(27);
+	var _Input = __webpack_require__(38);
 
 	var _Input2 = _interopRequireDefault(_Input);
 
-	var _Select = __webpack_require__(28);
+	var _Select = __webpack_require__(39);
 
 	var _Select2 = _interopRequireDefault(_Select);
 
-	var _DropdownListInput = __webpack_require__(30);
+	var _DropdownListInput = __webpack_require__(41);
 
 	var _DropdownListInput2 = _interopRequireDefault(_DropdownListInput);
 
-	var _Popup = __webpack_require__(34);
+	var _Popup = __webpack_require__(45);
 
 	var _Popup2 = _interopRequireDefault(_Popup);
 
-	var _compat = __webpack_require__(38);
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
-	var _List = __webpack_require__(40);
+	var _List = __webpack_require__(51);
 
 	var _List2 = _interopRequireDefault(_List);
 
-	var _ListGroupable = __webpack_require__(46);
+	var _ListGroupable = __webpack_require__(57);
 
 	var _ListGroupable2 = _interopRequireDefault(_ListGroupable);
 
-	var _validateListInterface = __webpack_require__(48);
+	var _validateListInterface = __webpack_require__(59);
 
 	var _validateListInterface2 = _interopRequireDefault(_validateListInterface);
 
-	var _uncontrollable = __webpack_require__(49);
+	var _uncontrollable = __webpack_require__(60);
 
 	var _uncontrollable2 = _interopRequireDefault(_uncontrollable);
 
-	var _dataHelpers = __webpack_require__(33);
+	var _dataHelpers = __webpack_require__(44);
 
-	var _interaction = __webpack_require__(43);
+	var _interaction = __webpack_require__(54);
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -1234,47 +2388,47 @@ return /******/ (function(modules) { // webpackBootstrap
 	var propTypes = _extends({}, _Popup2.default.propTypes, {
 
 	  //-- controlled props -----------
-	  value: _react2.default.PropTypes.any,
-	  onChange: _react2.default.PropTypes.func,
-	  open: _react2.default.PropTypes.bool,
-	  onToggle: _react2.default.PropTypes.func,
+	  value: _propTypes2.default.any,
+	  onChange: _propTypes2.default.func,
+	  open: _propTypes2.default.bool,
+	  onToggle: _propTypes2.default.func,
 	  //------------------------------------
 
-	  data: _react2.default.PropTypes.array,
-	  valueField: _react2.default.PropTypes.string,
-	  textField: _propTypes2.default.accessor,
+	  data: _propTypes2.default.array,
+	  valueField: _propTypes2.default.string,
+	  textField: _propTypes4.default.accessor,
 
-	  valueComponent: _propTypes2.default.elementType,
-	  itemComponent: _propTypes2.default.elementType,
-	  listComponent: _propTypes2.default.elementType,
+	  valueComponent: _propTypes4.default.elementType,
+	  itemComponent: _propTypes4.default.elementType,
+	  listComponent: _propTypes4.default.elementType,
 
-	  groupComponent: _propTypes2.default.elementType,
-	  groupBy: _propTypes2.default.accessor,
+	  groupComponent: _propTypes4.default.elementType,
+	  groupBy: _propTypes4.default.accessor,
 
-	  onSelect: _react2.default.PropTypes.func,
-	  searchTerm: _react2.default.PropTypes.string,
-	  onSearch: _react2.default.PropTypes.func,
-	  busy: _react2.default.PropTypes.bool,
-	  delay: _react2.default.PropTypes.number,
-	  dropUp: _react2.default.PropTypes.bool,
-	  duration: _react2.default.PropTypes.number, //popup
+	  onSelect: _propTypes2.default.func,
+	  searchTerm: _propTypes2.default.string,
+	  onSearch: _propTypes2.default.func,
+	  busy: _propTypes2.default.bool,
+	  delay: _propTypes2.default.number,
+	  dropUp: _propTypes2.default.bool,
+	  duration: _propTypes2.default.number, //popup
 
-	  disabled: _propTypes2.default.disabled.acceptsArray,
-	  readOnly: _propTypes2.default.readOnly.acceptsArray,
+	  disabled: _propTypes4.default.disabled.acceptsArray,
+	  readOnly: _propTypes4.default.readOnly.acceptsArray,
 
-	  messages: _react2.default.PropTypes.shape({
-	    open: _propTypes2.default.message,
-	    emptyList: _propTypes2.default.message,
-	    emptyFilter: _propTypes2.default.message,
-	    filterPlaceholder: _propTypes2.default.message
+	  messages: _propTypes2.default.shape({
+	    open: _propTypes4.default.message,
+	    emptyList: _propTypes4.default.message,
+	    emptyFilter: _propTypes4.default.message,
+	    filterPlaceholder: _propTypes4.default.message
 	  })
 	});
 
-	var DropdownList = _react2.default.createClass((_obj = {
+	var DropdownList = (0, _createReactClass2.default)((_obj = {
 
 	  displayName: 'DropdownList',
 
-	  mixins: [__webpack_require__(52), __webpack_require__(53), __webpack_require__(54), __webpack_require__(55), __webpack_require__(56), __webpack_require__(61), __webpack_require__(45)(), __webpack_require__(62)({
+	  mixins: [__webpack_require__(63), __webpack_require__(64), __webpack_require__(65), __webpack_require__(66), __webpack_require__(67), __webpack_require__(72), __webpack_require__(56)(), __webpack_require__(73)({
 	    didHandle: function didHandle(focused) {
 	      if (!focused) this.close();
 	    }
@@ -1483,122 +2637,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    (0, _widgetHelpers.notify)(this.props.onSelect, data);
 	    this.change(data);
 	    this.focus(this);
-	  },
-	  handleClick: function handleClick(e) {
-	    var wrapper = this.refs.filterWrapper;
-
-	    if (!this.props.filter || !this.props.open) this.toggle();else if (!(0, _contains2.default)(_compat2.default.findDOMNode(wrapper), e.target)) this.close();
-
-	    (0, _widgetHelpers.notify)(this.props.onClick, e);
-	  },
-	  handleKeyDown: function handleKeyDown(e) {
-	    var _this3 = this;
-
-	    var key = e.key,
-	        alt = e.altKey,
-	        list = this.refs.list,
-	        filtering = this.props.filter,
-	        focusedItem = this.state.focusedItem,
-	        selectedItem = this.state.selectedItem,
-	        isOpen = this.props.open,
-	        closeWithFocus = function closeWithFocus() {
-	      _this3.close(), _compat2.default.findDOMNode(_this3).focus();
-	    };
-
-	    (0, _widgetHelpers.notify)(this.props.onKeyDown, [e]);
-
-	    var change = function change(item, fromList) {
-	      if (item == null) return;
-	      fromList ? _this3.handleSelect(item) : _this3.change(item);
-	    };
-
-	    if (e.defaultPrevented) return;
-
-	    if (key === 'End') {
-	      e.preventDefault();
-
-	      if (isOpen) this.setState({ focusedItem: list.last() });else change(list.last());
-	    } else if (key === 'Home') {
-	      e.preventDefault();
-
-	      if (isOpen) this.setState({ focusedItem: list.first() });else change(list.first());
-	    } else if (key === 'Escape' && isOpen) {
-	      e.preventDefault();
-	      closeWithFocus();
-	    } else if ((key === 'Enter' || key === ' ' && !filtering) && isOpen) {
-	      e.preventDefault();
-	      change(this.state.focusedItem, true);
-	    } else if (key === ' ' && !filtering && !isOpen) {
-	      e.preventDefault();
-	      this.open();
-	    } else if (key === 'ArrowDown') {
-	      if (alt) this.open();else if (isOpen) this.setState({ focusedItem: list.next(focusedItem) });else change(list.next(selectedItem));
-	      e.preventDefault();
-	    } else if (key === 'ArrowUp') {
-	      if (alt) closeWithFocus();else if (isOpen) this.setState({ focusedItem: list.prev(focusedItem) });else change(list.prev(selectedItem));
-	      e.preventDefault();
-	    }
-	  },
-	  handleKeyPress: function handleKeyPress(e) {
-	    var _this4 = this;
-
-	    (0, _widgetHelpers.notify)(this.props.onKeyPress, [e]);
-
-	    if (e.defaultPrevented) return;
-
-	    if (!(this.props.filter && this.props.open)) this.search(String.fromCharCode(e.which), function (item) {
-	      _this4.isMounted() && _this4.props.open ? _this4.setState({ focusedItem: item }) : item && _this4.change(item);
-	    });
-	  },
-	  change: function change(data) {
-	    if (!(0, _dataHelpers.valueMatcher)(data, this.props.value, this.props.valueField)) {
-	      (0, _widgetHelpers.notify)(this.props.onChange, data);
-	      (0, _widgetHelpers.notify)(this.props.onSearch, '');
-	      this.close();
-	    }
-	  },
-	  focus: function focus(target) {
-	    var _props4 = this.props,
-	        filter = _props4.filter,
-	        open = _props4.open;
-
-	    var inst = target || (filter && open ? this.refs.filter : this.refs.input);
-
-	    inst = _compat2.default.findDOMNode(inst);
-
-	    if ((0, _activeElement2.default)() !== inst) inst.focus();
-	  },
-	  _data: function _data() {
-	    return this.state.filteredData || this.props.data.concat();
-	  },
-	  search: function search(character, cb) {
-	    var _this5 = this;
-
-	    var word = ((this._searchTerm || '') + character).toLowerCase();
-
-	    if (!character) return;
-
-	    this._searchTerm = word;
-
-	    this.setTimeout('search', function () {
-	      var list = _this5.refs.list,
-	          key = _this5.props.open ? 'focusedItem' : 'selectedItem',
-	          item = list.next(_this5.state[key], word);
-
-	      _this5._searchTerm = '';
-	      if (item) cb(item);
-	    }, this.props.delay);
-	  },
-	  open: function open() {
-	    (0, _widgetHelpers.notify)(this.props.onToggle, true);
-	  },
-	  close: function close() {
-	    (0, _widgetHelpers.notify)(this.props.onToggle, false);
-	  },
-	  toggle: function toggle() {
-	    this.props.open ? this.close() : this.open();
 	  }
-	}, (_applyDecoratedDescriptor(_obj, 'handleSelect', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleSelect'), _obj), _applyDecoratedDescriptor(_obj, 'handleClick', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleClick'), _obj), _applyDecoratedDescriptor(_obj, 'handleKeyDown', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleKeyDown'), _obj), _applyDecoratedDescriptor(_obj, 'handleKeyPress', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleKeyPress'), _obj)), _obj));
+	}, (_applyDecoratedDescriptor(_obj, 'handleSelect', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleSelect'), _obj)), _obj));
 
 	function msgs(msgs) {
 	  return _extends({
@@ -1612,9 +2652,1052 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = (0, _uncontrollable2.default)(DropdownList, { open: 'onToggle', value: 'onChange', searchTerm: 'onSearch' }, ['focus']);
 	module.exports = exports['default'];
 
-/***/ },
-/* 22 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 31 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 *
+	 */
+
+	'use strict';
+
+	var React = __webpack_require__(29);
+	var factory = __webpack_require__(32);
+
+	if (typeof React === 'undefined') {
+	  throw Error(
+	    'create-react-class could not find the React object. If you are using script tags, ' +
+	      'make sure that React is being loaded before create-react-class.'
+	  );
+	}
+
+	// Hack to grab NoopUpdateQueue from isomorphic React
+	var ReactNoopUpdateQueue = new React.Component().updater;
+
+	module.exports = factory(
+	  React.Component,
+	  React.isValidElement,
+	  ReactNoopUpdateQueue
+	);
+
+
+/***/ }),
+/* 32 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(process) {/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 *
+	 */
+
+	'use strict';
+
+	var _assign = __webpack_require__(25);
+
+	// -- Inlined from fbjs --
+
+	var emptyObject = {};
+
+	if (process.env.NODE_ENV !== 'production') {
+	  Object.freeze(emptyObject);
+	}
+
+	var validateFormat = function validateFormat(format) {};
+
+	if (process.env.NODE_ENV !== 'production') {
+	  validateFormat = function validateFormat(format) {
+	    if (format === undefined) {
+	      throw new Error('invariant requires an error message argument');
+	    }
+	  };
+	}
+
+	function _invariant(condition, format, a, b, c, d, e, f) {
+	  validateFormat(format);
+
+	  if (!condition) {
+	    var error;
+	    if (format === undefined) {
+	      error = new Error('Minified exception occurred; use the non-minified dev environment ' + 'for the full error message and additional helpful warnings.');
+	    } else {
+	      var args = [a, b, c, d, e, f];
+	      var argIndex = 0;
+	      error = new Error(format.replace(/%s/g, function () {
+	        return args[argIndex++];
+	      }));
+	      error.name = 'Invariant Violation';
+	    }
+
+	    error.framesToPop = 1; // we don't care about invariant's own frame
+	    throw error;
+	  }
+	}
+
+	var warning = function(){};
+
+	if (process.env.NODE_ENV !== 'production') {
+	  var printWarning = function printWarning(format) {
+	    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+	      args[_key - 1] = arguments[_key];
+	    }
+
+	    var argIndex = 0;
+	    var message = 'Warning: ' + format.replace(/%s/g, function () {
+	      return args[argIndex++];
+	    });
+	    if (typeof console !== 'undefined') {
+	      console.error(message);
+	    }
+	    try {
+	      // --- Welcome to debugging React ---
+	      // This error was thrown as a convenience so that you can use this stack
+	      // to find the callsite that caused this warning to fire.
+	      throw new Error(message);
+	    } catch (x) {}
+	  };
+
+	  warning = function warning(condition, format) {
+	    if (format === undefined) {
+	      throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
+	    }
+
+	    if (format.indexOf('Failed Composite propType: ') === 0) {
+	      return; // Ignore CompositeComponent proptype check.
+	    }
+
+	    if (!condition) {
+	      for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+	        args[_key2 - 2] = arguments[_key2];
+	      }
+
+	      printWarning.apply(undefined, [format].concat(args));
+	    }
+	  };
+	}
+
+	// /-- Inlined from fbjs --
+
+	var MIXINS_KEY = 'mixins';
+
+	// Helper function to allow the creation of anonymous functions which do not
+	// have .name set to the name of the variable being assigned to.
+	function identity(fn) {
+	  return fn;
+	}
+
+	var ReactPropTypeLocationNames;
+	if (process.env.NODE_ENV !== 'production') {
+	  ReactPropTypeLocationNames = {
+	    prop: 'prop',
+	    context: 'context',
+	    childContext: 'child context'
+	  };
+	} else {
+	  ReactPropTypeLocationNames = {};
+	}
+
+	function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
+	  /**
+	   * Policies that describe methods in `ReactClassInterface`.
+	   */
+
+	  var injectedMixins = [];
+
+	  /**
+	   * Composite components are higher-level components that compose other composite
+	   * or host components.
+	   *
+	   * To create a new type of `ReactClass`, pass a specification of
+	   * your new class to `React.createClass`. The only requirement of your class
+	   * specification is that you implement a `render` method.
+	   *
+	   *   var MyComponent = React.createClass({
+	   *     render: function() {
+	   *       return <div>Hello World</div>;
+	   *     }
+	   *   });
+	   *
+	   * The class specification supports a specific protocol of methods that have
+	   * special meaning (e.g. `render`). See `ReactClassInterface` for
+	   * more the comprehensive protocol. Any other properties and methods in the
+	   * class specification will be available on the prototype.
+	   *
+	   * @interface ReactClassInterface
+	   * @internal
+	   */
+	  var ReactClassInterface = {
+	    /**
+	     * An array of Mixin objects to include when defining your component.
+	     *
+	     * @type {array}
+	     * @optional
+	     */
+	    mixins: 'DEFINE_MANY',
+
+	    /**
+	     * An object containing properties and methods that should be defined on
+	     * the component's constructor instead of its prototype (static methods).
+	     *
+	     * @type {object}
+	     * @optional
+	     */
+	    statics: 'DEFINE_MANY',
+
+	    /**
+	     * Definition of prop types for this component.
+	     *
+	     * @type {object}
+	     * @optional
+	     */
+	    propTypes: 'DEFINE_MANY',
+
+	    /**
+	     * Definition of context types for this component.
+	     *
+	     * @type {object}
+	     * @optional
+	     */
+	    contextTypes: 'DEFINE_MANY',
+
+	    /**
+	     * Definition of context types this component sets for its children.
+	     *
+	     * @type {object}
+	     * @optional
+	     */
+	    childContextTypes: 'DEFINE_MANY',
+
+	    // ==== Definition methods ====
+
+	    /**
+	     * Invoked when the component is mounted. Values in the mapping will be set on
+	     * `this.props` if that prop is not specified (i.e. using an `in` check).
+	     *
+	     * This method is invoked before `getInitialState` and therefore cannot rely
+	     * on `this.state` or use `this.setState`.
+	     *
+	     * @return {object}
+	     * @optional
+	     */
+	    getDefaultProps: 'DEFINE_MANY_MERGED',
+
+	    /**
+	     * Invoked once before the component is mounted. The return value will be used
+	     * as the initial value of `this.state`.
+	     *
+	     *   getInitialState: function() {
+	     *     return {
+	     *       isOn: false,
+	     *       fooBaz: new BazFoo()
+	     *     }
+	     *   }
+	     *
+	     * @return {object}
+	     * @optional
+	     */
+	    getInitialState: 'DEFINE_MANY_MERGED',
+
+	    /**
+	     * @return {object}
+	     * @optional
+	     */
+	    getChildContext: 'DEFINE_MANY_MERGED',
+
+	    /**
+	     * Uses props from `this.props` and state from `this.state` to render the
+	     * structure of the component.
+	     *
+	     * No guarantees are made about when or how often this method is invoked, so
+	     * it must not have side effects.
+	     *
+	     *   render: function() {
+	     *     var name = this.props.name;
+	     *     return <div>Hello, {name}!</div>;
+	     *   }
+	     *
+	     * @return {ReactComponent}
+	     * @required
+	     */
+	    render: 'DEFINE_ONCE',
+
+	    // ==== Delegate methods ====
+
+	    /**
+	     * Invoked when the component is initially created and about to be mounted.
+	     * This may have side effects, but any external subscriptions or data created
+	     * by this method must be cleaned up in `componentWillUnmount`.
+	     *
+	     * @optional
+	     */
+	    componentWillMount: 'DEFINE_MANY',
+
+	    /**
+	     * Invoked when the component has been mounted and has a DOM representation.
+	     * However, there is no guarantee that the DOM node is in the document.
+	     *
+	     * Use this as an opportunity to operate on the DOM when the component has
+	     * been mounted (initialized and rendered) for the first time.
+	     *
+	     * @param {DOMElement} rootNode DOM element representing the component.
+	     * @optional
+	     */
+	    componentDidMount: 'DEFINE_MANY',
+
+	    /**
+	     * Invoked before the component receives new props.
+	     *
+	     * Use this as an opportunity to react to a prop transition by updating the
+	     * state using `this.setState`. Current props are accessed via `this.props`.
+	     *
+	     *   componentWillReceiveProps: function(nextProps, nextContext) {
+	     *     this.setState({
+	     *       likesIncreasing: nextProps.likeCount > this.props.likeCount
+	     *     });
+	     *   }
+	     *
+	     * NOTE: There is no equivalent `componentWillReceiveState`. An incoming prop
+	     * transition may cause a state change, but the opposite is not true. If you
+	     * need it, you are probably looking for `componentWillUpdate`.
+	     *
+	     * @param {object} nextProps
+	     * @optional
+	     */
+	    componentWillReceiveProps: 'DEFINE_MANY',
+
+	    /**
+	     * Invoked while deciding if the component should be updated as a result of
+	     * receiving new props, state and/or context.
+	     *
+	     * Use this as an opportunity to `return false` when you're certain that the
+	     * transition to the new props/state/context will not require a component
+	     * update.
+	     *
+	     *   shouldComponentUpdate: function(nextProps, nextState, nextContext) {
+	     *     return !equal(nextProps, this.props) ||
+	     *       !equal(nextState, this.state) ||
+	     *       !equal(nextContext, this.context);
+	     *   }
+	     *
+	     * @param {object} nextProps
+	     * @param {?object} nextState
+	     * @param {?object} nextContext
+	     * @return {boolean} True if the component should update.
+	     * @optional
+	     */
+	    shouldComponentUpdate: 'DEFINE_ONCE',
+
+	    /**
+	     * Invoked when the component is about to update due to a transition from
+	     * `this.props`, `this.state` and `this.context` to `nextProps`, `nextState`
+	     * and `nextContext`.
+	     *
+	     * Use this as an opportunity to perform preparation before an update occurs.
+	     *
+	     * NOTE: You **cannot** use `this.setState()` in this method.
+	     *
+	     * @param {object} nextProps
+	     * @param {?object} nextState
+	     * @param {?object} nextContext
+	     * @param {ReactReconcileTransaction} transaction
+	     * @optional
+	     */
+	    componentWillUpdate: 'DEFINE_MANY',
+
+	    /**
+	     * Invoked when the component's DOM representation has been updated.
+	     *
+	     * Use this as an opportunity to operate on the DOM when the component has
+	     * been updated.
+	     *
+	     * @param {object} prevProps
+	     * @param {?object} prevState
+	     * @param {?object} prevContext
+	     * @param {DOMElement} rootNode DOM element representing the component.
+	     * @optional
+	     */
+	    componentDidUpdate: 'DEFINE_MANY',
+
+	    /**
+	     * Invoked when the component is about to be removed from its parent and have
+	     * its DOM representation destroyed.
+	     *
+	     * Use this as an opportunity to deallocate any external resources.
+	     *
+	     * NOTE: There is no `componentDidUnmount` since your component will have been
+	     * destroyed by that point.
+	     *
+	     * @optional
+	     */
+	    componentWillUnmount: 'DEFINE_MANY',
+
+	    /**
+	     * Replacement for (deprecated) `componentWillMount`.
+	     *
+	     * @optional
+	     */
+	    UNSAFE_componentWillMount: 'DEFINE_MANY',
+
+	    /**
+	     * Replacement for (deprecated) `componentWillReceiveProps`.
+	     *
+	     * @optional
+	     */
+	    UNSAFE_componentWillReceiveProps: 'DEFINE_MANY',
+
+	    /**
+	     * Replacement for (deprecated) `componentWillUpdate`.
+	     *
+	     * @optional
+	     */
+	    UNSAFE_componentWillUpdate: 'DEFINE_MANY',
+
+	    // ==== Advanced methods ====
+
+	    /**
+	     * Updates the component's currently mounted DOM representation.
+	     *
+	     * By default, this implements React's rendering and reconciliation algorithm.
+	     * Sophisticated clients may wish to override this.
+	     *
+	     * @param {ReactReconcileTransaction} transaction
+	     * @internal
+	     * @overridable
+	     */
+	    updateComponent: 'OVERRIDE_BASE'
+	  };
+
+	  /**
+	   * Similar to ReactClassInterface but for static methods.
+	   */
+	  var ReactClassStaticInterface = {
+	    /**
+	     * This method is invoked after a component is instantiated and when it
+	     * receives new props. Return an object to update state in response to
+	     * prop changes. Return null to indicate no change to state.
+	     *
+	     * If an object is returned, its keys will be merged into the existing state.
+	     *
+	     * @return {object || null}
+	     * @optional
+	     */
+	    getDerivedStateFromProps: 'DEFINE_MANY_MERGED'
+	  };
+
+	  /**
+	   * Mapping from class specification keys to special processing functions.
+	   *
+	   * Although these are declared like instance properties in the specification
+	   * when defining classes using `React.createClass`, they are actually static
+	   * and are accessible on the constructor instead of the prototype. Despite
+	   * being static, they must be defined outside of the "statics" key under
+	   * which all other static methods are defined.
+	   */
+	  var RESERVED_SPEC_KEYS = {
+	    displayName: function(Constructor, displayName) {
+	      Constructor.displayName = displayName;
+	    },
+	    mixins: function(Constructor, mixins) {
+	      if (mixins) {
+	        for (var i = 0; i < mixins.length; i++) {
+	          mixSpecIntoComponent(Constructor, mixins[i]);
+	        }
+	      }
+	    },
+	    childContextTypes: function(Constructor, childContextTypes) {
+	      if (process.env.NODE_ENV !== 'production') {
+	        validateTypeDef(Constructor, childContextTypes, 'childContext');
+	      }
+	      Constructor.childContextTypes = _assign(
+	        {},
+	        Constructor.childContextTypes,
+	        childContextTypes
+	      );
+	    },
+	    contextTypes: function(Constructor, contextTypes) {
+	      if (process.env.NODE_ENV !== 'production') {
+	        validateTypeDef(Constructor, contextTypes, 'context');
+	      }
+	      Constructor.contextTypes = _assign(
+	        {},
+	        Constructor.contextTypes,
+	        contextTypes
+	      );
+	    },
+	    /**
+	     * Special case getDefaultProps which should move into statics but requires
+	     * automatic merging.
+	     */
+	    getDefaultProps: function(Constructor, getDefaultProps) {
+	      if (Constructor.getDefaultProps) {
+	        Constructor.getDefaultProps = createMergedResultFunction(
+	          Constructor.getDefaultProps,
+	          getDefaultProps
+	        );
+	      } else {
+	        Constructor.getDefaultProps = getDefaultProps;
+	      }
+	    },
+	    propTypes: function(Constructor, propTypes) {
+	      if (process.env.NODE_ENV !== 'production') {
+	        validateTypeDef(Constructor, propTypes, 'prop');
+	      }
+	      Constructor.propTypes = _assign({}, Constructor.propTypes, propTypes);
+	    },
+	    statics: function(Constructor, statics) {
+	      mixStaticSpecIntoComponent(Constructor, statics);
+	    },
+	    autobind: function() {}
+	  };
+
+	  function validateTypeDef(Constructor, typeDef, location) {
+	    for (var propName in typeDef) {
+	      if (typeDef.hasOwnProperty(propName)) {
+	        // use a warning instead of an _invariant so components
+	        // don't show up in prod but only in __DEV__
+	        if (process.env.NODE_ENV !== 'production') {
+	          warning(
+	            typeof typeDef[propName] === 'function',
+	            '%s: %s type `%s` is invalid; it must be a function, usually from ' +
+	              'React.PropTypes.',
+	            Constructor.displayName || 'ReactClass',
+	            ReactPropTypeLocationNames[location],
+	            propName
+	          );
+	        }
+	      }
+	    }
+	  }
+
+	  function validateMethodOverride(isAlreadyDefined, name) {
+	    var specPolicy = ReactClassInterface.hasOwnProperty(name)
+	      ? ReactClassInterface[name]
+	      : null;
+
+	    // Disallow overriding of base class methods unless explicitly allowed.
+	    if (ReactClassMixin.hasOwnProperty(name)) {
+	      _invariant(
+	        specPolicy === 'OVERRIDE_BASE',
+	        'ReactClassInterface: You are attempting to override ' +
+	          '`%s` from your class specification. Ensure that your method names ' +
+	          'do not overlap with React methods.',
+	        name
+	      );
+	    }
+
+	    // Disallow defining methods more than once unless explicitly allowed.
+	    if (isAlreadyDefined) {
+	      _invariant(
+	        specPolicy === 'DEFINE_MANY' || specPolicy === 'DEFINE_MANY_MERGED',
+	        'ReactClassInterface: You are attempting to define ' +
+	          '`%s` on your component more than once. This conflict may be due ' +
+	          'to a mixin.',
+	        name
+	      );
+	    }
+	  }
+
+	  /**
+	   * Mixin helper which handles policy validation and reserved
+	   * specification keys when building React classes.
+	   */
+	  function mixSpecIntoComponent(Constructor, spec) {
+	    if (!spec) {
+	      if (process.env.NODE_ENV !== 'production') {
+	        var typeofSpec = typeof spec;
+	        var isMixinValid = typeofSpec === 'object' && spec !== null;
+
+	        if (process.env.NODE_ENV !== 'production') {
+	          warning(
+	            isMixinValid,
+	            "%s: You're attempting to include a mixin that is either null " +
+	              'or not an object. Check the mixins included by the component, ' +
+	              'as well as any mixins they include themselves. ' +
+	              'Expected object but got %s.',
+	            Constructor.displayName || 'ReactClass',
+	            spec === null ? null : typeofSpec
+	          );
+	        }
+	      }
+
+	      return;
+	    }
+
+	    _invariant(
+	      typeof spec !== 'function',
+	      "ReactClass: You're attempting to " +
+	        'use a component class or function as a mixin. Instead, just use a ' +
+	        'regular object.'
+	    );
+	    _invariant(
+	      !isValidElement(spec),
+	      "ReactClass: You're attempting to " +
+	        'use a component as a mixin. Instead, just use a regular object.'
+	    );
+
+	    var proto = Constructor.prototype;
+	    var autoBindPairs = proto.__reactAutoBindPairs;
+
+	    // By handling mixins before any other properties, we ensure the same
+	    // chaining order is applied to methods with DEFINE_MANY policy, whether
+	    // mixins are listed before or after these methods in the spec.
+	    if (spec.hasOwnProperty(MIXINS_KEY)) {
+	      RESERVED_SPEC_KEYS.mixins(Constructor, spec.mixins);
+	    }
+
+	    for (var name in spec) {
+	      if (!spec.hasOwnProperty(name)) {
+	        continue;
+	      }
+
+	      if (name === MIXINS_KEY) {
+	        // We have already handled mixins in a special case above.
+	        continue;
+	      }
+
+	      var property = spec[name];
+	      var isAlreadyDefined = proto.hasOwnProperty(name);
+	      validateMethodOverride(isAlreadyDefined, name);
+
+	      if (RESERVED_SPEC_KEYS.hasOwnProperty(name)) {
+	        RESERVED_SPEC_KEYS[name](Constructor, property);
+	      } else {
+	        // Setup methods on prototype:
+	        // The following member methods should not be automatically bound:
+	        // 1. Expected ReactClass methods (in the "interface").
+	        // 2. Overridden methods (that were mixed in).
+	        var isReactClassMethod = ReactClassInterface.hasOwnProperty(name);
+	        var isFunction = typeof property === 'function';
+	        var shouldAutoBind =
+	          isFunction &&
+	          !isReactClassMethod &&
+	          !isAlreadyDefined &&
+	          spec.autobind !== false;
+
+	        if (shouldAutoBind) {
+	          autoBindPairs.push(name, property);
+	          proto[name] = property;
+	        } else {
+	          if (isAlreadyDefined) {
+	            var specPolicy = ReactClassInterface[name];
+
+	            // These cases should already be caught by validateMethodOverride.
+	            _invariant(
+	              isReactClassMethod &&
+	                (specPolicy === 'DEFINE_MANY_MERGED' ||
+	                  specPolicy === 'DEFINE_MANY'),
+	              'ReactClass: Unexpected spec policy %s for key %s ' +
+	                'when mixing in component specs.',
+	              specPolicy,
+	              name
+	            );
+
+	            // For methods which are defined more than once, call the existing
+	            // methods before calling the new property, merging if appropriate.
+	            if (specPolicy === 'DEFINE_MANY_MERGED') {
+	              proto[name] = createMergedResultFunction(proto[name], property);
+	            } else if (specPolicy === 'DEFINE_MANY') {
+	              proto[name] = createChainedFunction(proto[name], property);
+	            }
+	          } else {
+	            proto[name] = property;
+	            if (process.env.NODE_ENV !== 'production') {
+	              // Add verbose displayName to the function, which helps when looking
+	              // at profiling tools.
+	              if (typeof property === 'function' && spec.displayName) {
+	                proto[name].displayName = spec.displayName + '_' + name;
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+
+	  function mixStaticSpecIntoComponent(Constructor, statics) {
+	    if (!statics) {
+	      return;
+	    }
+
+	    for (var name in statics) {
+	      var property = statics[name];
+	      if (!statics.hasOwnProperty(name)) {
+	        continue;
+	      }
+
+	      var isReserved = name in RESERVED_SPEC_KEYS;
+	      _invariant(
+	        !isReserved,
+	        'ReactClass: You are attempting to define a reserved ' +
+	          'property, `%s`, that shouldn\'t be on the "statics" key. Define it ' +
+	          'as an instance property instead; it will still be accessible on the ' +
+	          'constructor.',
+	        name
+	      );
+
+	      var isAlreadyDefined = name in Constructor;
+	      if (isAlreadyDefined) {
+	        var specPolicy = ReactClassStaticInterface.hasOwnProperty(name)
+	          ? ReactClassStaticInterface[name]
+	          : null;
+
+	        _invariant(
+	          specPolicy === 'DEFINE_MANY_MERGED',
+	          'ReactClass: You are attempting to define ' +
+	            '`%s` on your component more than once. This conflict may be ' +
+	            'due to a mixin.',
+	          name
+	        );
+
+	        Constructor[name] = createMergedResultFunction(Constructor[name], property);
+
+	        return;
+	      }
+
+	      Constructor[name] = property;
+	    }
+	  }
+
+	  /**
+	   * Merge two objects, but throw if both contain the same key.
+	   *
+	   * @param {object} one The first object, which is mutated.
+	   * @param {object} two The second object
+	   * @return {object} one after it has been mutated to contain everything in two.
+	   */
+	  function mergeIntoWithNoDuplicateKeys(one, two) {
+	    _invariant(
+	      one && two && typeof one === 'object' && typeof two === 'object',
+	      'mergeIntoWithNoDuplicateKeys(): Cannot merge non-objects.'
+	    );
+
+	    for (var key in two) {
+	      if (two.hasOwnProperty(key)) {
+	        _invariant(
+	          one[key] === undefined,
+	          'mergeIntoWithNoDuplicateKeys(): ' +
+	            'Tried to merge two objects with the same key: `%s`. This conflict ' +
+	            'may be due to a mixin; in particular, this may be caused by two ' +
+	            'getInitialState() or getDefaultProps() methods returning objects ' +
+	            'with clashing keys.',
+	          key
+	        );
+	        one[key] = two[key];
+	      }
+	    }
+	    return one;
+	  }
+
+	  /**
+	   * Creates a function that invokes two functions and merges their return values.
+	   *
+	   * @param {function} one Function to invoke first.
+	   * @param {function} two Function to invoke second.
+	   * @return {function} Function that invokes the two argument functions.
+	   * @private
+	   */
+	  function createMergedResultFunction(one, two) {
+	    return function mergedResult() {
+	      var a = one.apply(this, arguments);
+	      var b = two.apply(this, arguments);
+	      if (a == null) {
+	        return b;
+	      } else if (b == null) {
+	        return a;
+	      }
+	      var c = {};
+	      mergeIntoWithNoDuplicateKeys(c, a);
+	      mergeIntoWithNoDuplicateKeys(c, b);
+	      return c;
+	    };
+	  }
+
+	  /**
+	   * Creates a function that invokes two functions and ignores their return vales.
+	   *
+	   * @param {function} one Function to invoke first.
+	   * @param {function} two Function to invoke second.
+	   * @return {function} Function that invokes the two argument functions.
+	   * @private
+	   */
+	  function createChainedFunction(one, two) {
+	    return function chainedFunction() {
+	      one.apply(this, arguments);
+	      two.apply(this, arguments);
+	    };
+	  }
+
+	  /**
+	   * Binds a method to the component.
+	   *
+	   * @param {object} component Component whose method is going to be bound.
+	   * @param {function} method Method to be bound.
+	   * @return {function} The bound method.
+	   */
+	  function bindAutoBindMethod(component, method) {
+	    var boundMethod = method.bind(component);
+	    if (process.env.NODE_ENV !== 'production') {
+	      boundMethod.__reactBoundContext = component;
+	      boundMethod.__reactBoundMethod = method;
+	      boundMethod.__reactBoundArguments = null;
+	      var componentName = component.constructor.displayName;
+	      var _bind = boundMethod.bind;
+	      boundMethod.bind = function(newThis) {
+	        for (
+	          var _len = arguments.length,
+	            args = Array(_len > 1 ? _len - 1 : 0),
+	            _key = 1;
+	          _key < _len;
+	          _key++
+	        ) {
+	          args[_key - 1] = arguments[_key];
+	        }
+
+	        // User is trying to bind() an autobound method; we effectively will
+	        // ignore the value of "this" that the user is trying to use, so
+	        // let's warn.
+	        if (newThis !== component && newThis !== null) {
+	          if (process.env.NODE_ENV !== 'production') {
+	            warning(
+	              false,
+	              'bind(): React component methods may only be bound to the ' +
+	                'component instance. See %s',
+	              componentName
+	            );
+	          }
+	        } else if (!args.length) {
+	          if (process.env.NODE_ENV !== 'production') {
+	            warning(
+	              false,
+	              'bind(): You are binding a component method to the component. ' +
+	                'React does this for you automatically in a high-performance ' +
+	                'way, so you can safely remove this call. See %s',
+	              componentName
+	            );
+	          }
+	          return boundMethod;
+	        }
+	        var reboundMethod = _bind.apply(boundMethod, arguments);
+	        reboundMethod.__reactBoundContext = component;
+	        reboundMethod.__reactBoundMethod = method;
+	        reboundMethod.__reactBoundArguments = args;
+	        return reboundMethod;
+	      };
+	    }
+	    return boundMethod;
+	  }
+
+	  /**
+	   * Binds all auto-bound methods in a component.
+	   *
+	   * @param {object} component Component whose method is going to be bound.
+	   */
+	  function bindAutoBindMethods(component) {
+	    var pairs = component.__reactAutoBindPairs;
+	    for (var i = 0; i < pairs.length; i += 2) {
+	      var autoBindKey = pairs[i];
+	      var method = pairs[i + 1];
+	      component[autoBindKey] = bindAutoBindMethod(component, method);
+	    }
+	  }
+
+	  var IsMountedPreMixin = {
+	    componentDidMount: function() {
+	      this.__isMounted = true;
+	    }
+	  };
+
+	  var IsMountedPostMixin = {
+	    componentWillUnmount: function() {
+	      this.__isMounted = false;
+	    }
+	  };
+
+	  /**
+	   * Add more to the ReactClass base class. These are all legacy features and
+	   * therefore not already part of the modern ReactComponent.
+	   */
+	  var ReactClassMixin = {
+	    /**
+	     * TODO: This will be deprecated because state should always keep a consistent
+	     * type signature and the only use case for this, is to avoid that.
+	     */
+	    replaceState: function(newState, callback) {
+	      this.updater.enqueueReplaceState(this, newState, callback);
+	    },
+
+	    /**
+	     * Checks whether or not this composite component is mounted.
+	     * @return {boolean} True if mounted, false otherwise.
+	     * @protected
+	     * @final
+	     */
+	    isMounted: function() {
+	      if (process.env.NODE_ENV !== 'production') {
+	        warning(
+	          this.__didWarnIsMounted,
+	          '%s: isMounted is deprecated. Instead, make sure to clean up ' +
+	            'subscriptions and pending requests in componentWillUnmount to ' +
+	            'prevent memory leaks.',
+	          (this.constructor && this.constructor.displayName) ||
+	            this.name ||
+	            'Component'
+	        );
+	        this.__didWarnIsMounted = true;
+	      }
+	      return !!this.__isMounted;
+	    }
+	  };
+
+	  var ReactClassComponent = function() {};
+	  _assign(
+	    ReactClassComponent.prototype,
+	    ReactComponent.prototype,
+	    ReactClassMixin
+	  );
+
+	  /**
+	   * Creates a composite component class given a class specification.
+	   * See https://facebook.github.io/react/docs/top-level-api.html#react.createclass
+	   *
+	   * @param {object} spec Class specification (which must define `render`).
+	   * @return {function} Component constructor function.
+	   * @public
+	   */
+	  function createClass(spec) {
+	    // To keep our warnings more understandable, we'll use a little hack here to
+	    // ensure that Constructor.name !== 'Constructor'. This makes sure we don't
+	    // unnecessarily identify a class without displayName as 'Constructor'.
+	    var Constructor = identity(function(props, context, updater) {
+	      // This constructor gets overridden by mocks. The argument is used
+	      // by mocks to assert on what gets mounted.
+
+	      if (process.env.NODE_ENV !== 'production') {
+	        warning(
+	          this instanceof Constructor,
+	          'Something is calling a React component directly. Use a factory or ' +
+	            'JSX instead. See: https://fb.me/react-legacyfactory'
+	        );
+	      }
+
+	      // Wire up auto-binding
+	      if (this.__reactAutoBindPairs.length) {
+	        bindAutoBindMethods(this);
+	      }
+
+	      this.props = props;
+	      this.context = context;
+	      this.refs = emptyObject;
+	      this.updater = updater || ReactNoopUpdateQueue;
+
+	      this.state = null;
+
+	      // ReactClasses doesn't have constructors. Instead, they use the
+	      // getInitialState and componentWillMount methods for initialization.
+
+	      var initialState = this.getInitialState ? this.getInitialState() : null;
+	      if (process.env.NODE_ENV !== 'production') {
+	        // We allow auto-mocks to proceed as if they're returning null.
+	        if (
+	          initialState === undefined &&
+	          this.getInitialState._isMockFunction
+	        ) {
+	          // This is probably bad practice. Consider warning here and
+	          // deprecating this convenience.
+	          initialState = null;
+	        }
+	      }
+	      _invariant(
+	        typeof initialState === 'object' && !Array.isArray(initialState),
+	        '%s.getInitialState(): must return an object or null',
+	        Constructor.displayName || 'ReactCompositeComponent'
+	      );
+
+	      this.state = initialState;
+	    });
+	    Constructor.prototype = new ReactClassComponent();
+	    Constructor.prototype.constructor = Constructor;
+	    Constructor.prototype.__reactAutoBindPairs = [];
+
+	    injectedMixins.forEach(mixSpecIntoComponent.bind(null, Constructor));
+
+	    mixSpecIntoComponent(Constructor, IsMountedPreMixin);
+	    mixSpecIntoComponent(Constructor, spec);
+	    mixSpecIntoComponent(Constructor, IsMountedPostMixin);
+
+	    // Initialize the defaultProps property after all mixins have been merged.
+	    if (Constructor.getDefaultProps) {
+	      Constructor.defaultProps = Constructor.getDefaultProps();
+	    }
+
+	    if (process.env.NODE_ENV !== 'production') {
+	      // This is a tag to indicate that the use of these method names is ok,
+	      // since it's used with createClass. If it's not, then it's likely a
+	      // mistake so we'll warn you to use the static property, property
+	      // initializer or constructor respectively.
+	      if (Constructor.getDefaultProps) {
+	        Constructor.getDefaultProps.isReactClassApproved = {};
+	      }
+	      if (Constructor.prototype.getInitialState) {
+	        Constructor.prototype.getInitialState.isReactClassApproved = {};
+	      }
+	    }
+
+	    _invariant(
+	      Constructor.prototype.render,
+	      'createClass(...): Class specification must implement a `render` method.'
+	    );
+
+	    if (process.env.NODE_ENV !== 'production') {
+	      warning(
+	        !Constructor.prototype.componentShouldUpdate,
+	        '%s has a method called ' +
+	          'componentShouldUpdate(). Did you mean shouldComponentUpdate()? ' +
+	          'The name is phrased as a question because the function is ' +
+	          'expected to return a value.',
+	        spec.displayName || 'A component'
+	      );
+	      warning(
+	        !Constructor.prototype.componentWillRecieveProps,
+	        '%s has a method called ' +
+	          'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?',
+	        spec.displayName || 'A component'
+	      );
+	      warning(
+	        !Constructor.prototype.UNSAFE_componentWillRecieveProps,
+	        '%s has a method called UNSAFE_componentWillRecieveProps(). ' +
+	          'Did you mean UNSAFE_componentWillReceiveProps()?',
+	        spec.displayName || 'A component'
+	      );
+	    }
+
+	    // Reduce time spent doing lookups by setting these on the prototype.
+	    for (var methodName in ReactClassInterface) {
+	      if (!Constructor.prototype[methodName]) {
+	        Constructor.prototype[methodName] = null;
+	      }
+	    }
+
+	    return Constructor;
+	  }
+
+	  return createClass;
+	}
+
+	module.exports = factory;
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
+
+/***/ }),
+/* 33 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -1627,7 +3710,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 */
 	exports['default'] = activeElement;
 
-	var _ownerDocument = __webpack_require__(23);
+	var _ownerDocument = __webpack_require__(34);
 
 	var _ownerDocument2 = babelHelpers.interopRequireDefault(_ownerDocument);
 
@@ -1641,9 +3724,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = exports['default'];
 
-/***/ },
-/* 23 */
-/***/ function(module, exports) {
+/***/ }),
+/* 34 */
+/***/ (function(module, exports) {
 
 	"use strict";
 
@@ -1656,9 +3739,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = exports["default"];
 
-/***/ },
-/* 24 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 35 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 	var canUseDOM = __webpack_require__(14);
@@ -1681,12 +3764,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = contains;
 
-/***/ },
-/* 25 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 36 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
-	  Copyright (c) 2016 Jed Watson.
+	  Copyright (c) 2018 Jed Watson.
 	  Licensed under the MIT License (MIT), see
 	  http://jedwatson.github.io/classnames
 	*/
@@ -1697,7 +3780,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 		var hasOwn = {}.hasOwnProperty;
 
-		function classNames () {
+		function classNames() {
 			var classes = [];
 
 			for (var i = 0; i < arguments.length; i++) {
@@ -1709,12 +3792,21 @@ return /******/ (function(modules) { // webpackBootstrap
 				if (argType === 'string' || argType === 'number') {
 					classes.push(arg);
 				} else if (Array.isArray(arg)) {
-					classes.push(classNames.apply(null, arg));
-				} else if (argType === 'object') {
-					for (var key in arg) {
-						if (hasOwn.call(arg, key) && arg[key]) {
-							classes.push(key);
+					if (arg.length) {
+						var inner = classNames.apply(null, arg);
+						if (inner) {
+							classes.push(inner);
 						}
+					}
+				} else if (argType === 'object') {
+					if (arg.toString === Object.prototype.toString) {
+						for (var key in arg) {
+							if (hasOwn.call(arg, key) && arg[key]) {
+								classes.push(key);
+							}
+						}
+					} else {
+						classes.push(arg.toString());
 					}
 				}
 			}
@@ -1723,6 +3815,7 @@ return /******/ (function(modules) { // webpackBootstrap
 		}
 
 		if (typeof module !== 'undefined' && module.exports) {
+			classNames.default = classNames;
 			module.exports = classNames;
 		} else if (true) {
 			// register as 'classnames', consistent with npm package name
@@ -1735,9 +3828,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}());
 
 
-/***/ },
-/* 26 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 37 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -1747,11 +3840,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _class, _temp;
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _classnames = __webpack_require__(25);
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
@@ -1798,21 +3895,21 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  return Widget;
 	}(_react2.default.Component), _class.propTypes = {
-	  tabIndex: _react.PropTypes.node,
-	  focused: _react.PropTypes.bool,
-	  disabled: _react.PropTypes.bool,
-	  readOnly: _react.PropTypes.bool,
-	  open: _react.PropTypes.bool,
-	  dropUp: _react.PropTypes.bool
+	  tabIndex: _propTypes2.default.node,
+	  focused: _propTypes2.default.bool,
+	  disabled: _propTypes2.default.bool,
+	  readOnly: _propTypes2.default.bool,
+	  open: _propTypes2.default.bool,
+	  dropUp: _propTypes2.default.bool
 	}, _class.contextTypes = {
-	  isRtl: _react.PropTypes.bool
+	  isRtl: _propTypes2.default.bool
 	}, _temp);
 	exports.default = Widget;
 	module.exports = exports['default'];
 
-/***/ },
-/* 27 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 38 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -1820,11 +3917,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _classnames = __webpack_require__(25);
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
@@ -1877,9 +3974,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = Input;
 	module.exports = exports['default'];
 
-/***/ },
-/* 28 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 39 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -1887,15 +3984,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _classnames = __webpack_require__(25);
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
-	var _Button = __webpack_require__(29);
+	var _Button = __webpack_require__(40);
 
 	var _Button2 = _interopRequireDefault(_Button);
 
@@ -1934,9 +4031,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = Select;
 	module.exports = exports['default'];
 
-/***/ },
-/* 29 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 40 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -1944,11 +4041,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _classnames = __webpack_require__(25);
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
@@ -2013,9 +4110,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = Button;
 	module.exports = exports['default'];
 
-/***/ },
-/* 30 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 41 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -2023,15 +4120,19 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _class, _temp;
 
-	var _react = __webpack_require__(20);
-
-	var _react2 = _interopRequireDefault(_react);
-
-	var _propTypes = __webpack_require__(31);
+	var _propTypes = __webpack_require__(20);
 
 	var _propTypes2 = _interopRequireDefault(_propTypes);
 
-	var _dataHelpers = __webpack_require__(33);
+	var _react = __webpack_require__(29);
+
+	var _react2 = _interopRequireDefault(_react);
+
+	var _propTypes3 = __webpack_require__(42);
+
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
+
+	var _dataHelpers = __webpack_require__(44);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2071,21 +4172,25 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  return DropdownListInput;
 	}(_react2.default.Component), _class.propTypes = {
-	  value: _react.PropTypes.any,
-	  placeholder: _react.PropTypes.string,
-	  textField: _propTypes2.default.accessor,
-	  valueComponent: _propTypes2.default.elementType
+	  value: _propTypes2.default.any,
+	  placeholder: _propTypes2.default.string,
+	  textField: _propTypes4.default.accessor,
+	  valueComponent: _propTypes4.default.elementType
 	}, _temp);
 	exports.default = DropdownListInput;
 	module.exports = exports['default'];
 
-/***/ },
-/* 31 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 42 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
@@ -2093,7 +4198,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _localizers2 = _interopRequireDefault(_localizers);
 
-	var _filter = __webpack_require__(32);
+	var _filter = __webpack_require__(43);
 
 	var _filter2 = _interopRequireDefault(_filter);
 
@@ -2104,10 +4209,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 	function getInteractionPropType(key) {
-	  var types = [_react.PropTypes.bool, _react.PropTypes.oneOf([key])],
-	      propType = _react.PropTypes.oneOfType(types);
+	  var types = [_propTypes2.default.bool, _propTypes2.default.oneOf([key])],
+	      propType = _propTypes2.default.oneOfType(types);
 
-	  propType.acceptsArray = _react.PropTypes.oneOfType(types.concat(_react.PropTypes.array));
+	  propType.acceptsArray = _propTypes2.default.oneOfType(types.concat(_propTypes2.default.array));
 
 	  return propType;
 	}
@@ -2139,11 +4244,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	  disabled: getInteractionPropType('disabled'),
 	  readOnly: getInteractionPropType('readOnly'),
 
-	  accessor: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.func]),
+	  accessor: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.func]),
 
-	  message: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.node, _react2.default.PropTypes.string]),
+	  message: _propTypes2.default.oneOfType([_propTypes2.default.node, _propTypes2.default.string]),
 
-	  filter: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.func, _react2.default.PropTypes.bool, _react2.default.PropTypes.oneOf(filterTypes)])
+	  filter: _propTypes2.default.oneOfType([_propTypes2.default.func, _propTypes2.default.bool, _propTypes2.default.oneOf(filterTypes)])
 	};
 
 	function createChainableTypeChecker(validate) {
@@ -2168,9 +4273,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return chainedCheckType;
 	}
 
-/***/ },
-/* 32 */
-/***/ function(module, exports) {
+/***/ }),
+/* 43 */
+/***/ (function(module, exports) {
 
 	"use strict";
 
@@ -2211,9 +4316,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = common;
 	module.exports = exports['default'];
 
-/***/ },
-/* 33 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 44 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -2277,19 +4382,24 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return item;
 	}
 
-/***/ },
-/* 34 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 45 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
+	exports.default = undefined;
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _OVERFLOW;
+	var _OVERFLOW, _class, _temp2;
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
@@ -2301,7 +4411,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _style2 = _interopRequireDefault(_style);
 
-	var _height = __webpack_require__(35);
+	var _height = __webpack_require__(46);
 
 	var _height2 = _interopRequireDefault(_height);
 
@@ -2313,15 +4423,21 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _configuration2 = _interopRequireDefault(_configuration);
 
-	var _classnames = __webpack_require__(25);
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
-	var _compat = __webpack_require__(38);
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 	var transform = (0, _camelizeStyle2.default)(_configuration2.default.animate.transform);
 
@@ -2343,56 +4459,150 @@ return /******/ (function(modules) { // webpackBootstrap
 	var OVERFLOW = (_OVERFLOW = {}, _OVERFLOW[CLOSED] = 'hidden', _OVERFLOW[CLOSING] = 'hidden', _OVERFLOW[OPENING] = 'hidden', _OVERFLOW);
 
 	var propTypes = {
-	  open: _react2.default.PropTypes.bool,
-	  dropUp: _react2.default.PropTypes.bool,
-	  duration: _react2.default.PropTypes.number,
+	  open: _propTypes2.default.bool,
+	  dropUp: _propTypes2.default.bool,
+	  duration: _propTypes2.default.number,
 
-	  onClosing: _react2.default.PropTypes.func,
-	  onOpening: _react2.default.PropTypes.func,
-	  onClose: _react2.default.PropTypes.func,
-	  onOpen: _react2.default.PropTypes.func
+	  onClosing: _propTypes2.default.func,
+	  onOpening: _propTypes2.default.func,
+	  onClose: _propTypes2.default.func,
+	  onOpen: _propTypes2.default.func
 	};
 
-	exports.default = _react2.default.createClass({
+	var _default = (_temp2 = _class = function (_React$Component) {
+	  _inherits(_default, _React$Component);
 
-	  displayName: 'Popup',
+	  function _default() {
+	    var _temp, _this, _ret;
 
-	  propTypes: propTypes,
+	    _classCallCheck(this, _default);
 
-	  getInitialState: function getInitialState() {
-	    return {
+	    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+	      args[_key] = arguments[_key];
+	    }
+
+	    return _ret = (_temp = (_this = _possibleConstructorReturn(this, _React$Component.call.apply(_React$Component, [this].concat(args))), _this), _this.state = {
 	      initialRender: true,
-	      status: this.props.open ? OPENING : CLOSED
-	    };
-	  },
-	  getDefaultProps: function getDefaultProps() {
-	    return {
-	      duration: 200,
-	      open: false,
-	      onClosing: function onClosing() {},
-	      onOpening: function onOpening() {},
-	      onClose: function onClose() {},
-	      onOpen: function onOpen() {}
-	    };
-	  },
-	  componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
+	      status: _this.props.open ? OPENING : CLOSED
+	    }, _this.renderChildren = function () {
+	      if (!_this.props.children) return _react2.default.createElement('span', { className: 'rw-popup rw-widget' });
+
+	      var offset = _this.getOffsetForStatus(_this.state.status),
+	          child = _react2.default.Children.only(_this.props.children);
+
+	      return (0, _react.cloneElement)(child, {
+	        style: _extends({}, child.props.style, offset, {
+	          position: _this.isTransitioning() ? 'absolute' : undefined
+	        }),
+	        className: (0, _classnames2.default)(child.props.className, 'rw-popup rw-widget')
+	      });
+	    }, _this.open = function () {
+	      _this.cancelNextCallback();
+	      var el = _compat2.default.findDOMNode(_this).firstChild,
+	          height = _this.height();
+
+	      _this.props.onOpening();
+
+	      _this.safeSetState({ status: OPENING, height: height }, function () {
+	        var offset = _this.getOffsetForStatus(OPEN),
+	            duration = _this.props.duration;
+
+	        _this.animate(el, offset, duration, 'ease', function () {
+	          _this.safeSetState({ status: OPEN }, function () {
+	            _this.props.onOpen();
+	          });
+	        });
+	      });
+	    }, _this.close = function () {
+	      _this.cancelNextCallback();
+	      var el = _compat2.default.findDOMNode(_this).firstChild,
+	          height = _this.height();
+
+	      _this.props.onClosing();
+
+	      _this.safeSetState({ status: CLOSING, height: height }, function () {
+	        var offset = _this.getOffsetForStatus(CLOSED),
+	            duration = _this.props.duration;
+
+	        _this.animate(el, offset, duration, 'ease', function () {
+	          return _this.safeSetState({ status: CLOSED }, function () {
+	            _this.props.onClose();
+	          });
+	        });
+	      });
+	    }, _this.getOffsetForStatus = function (status) {
+	      var _CLOSED$CLOSING$OPENI;
+
+	      if (_this.state.initialRender) return {};
+
+	      var _in = properties('top', _this.props.dropUp ? '100%' : '-100%'),
+	          out = properties('top', 0);
+	      return (_CLOSED$CLOSING$OPENI = {}, _CLOSED$CLOSING$OPENI[CLOSED] = _in, _CLOSED$CLOSING$OPENI[CLOSING] = out, _CLOSED$CLOSING$OPENI[OPENING] = _in, _CLOSED$CLOSING$OPENI[OPEN] = out, _CLOSED$CLOSING$OPENI)[status] || {};
+	    }, _this.height = function () {
+	      var container = _compat2.default.findDOMNode(_this),
+	          content = container.firstChild,
+	          margin = parseInt((0, _style2.default)(content, 'margin-top'), 10) + parseInt((0, _style2.default)(content, 'margin-bottom'), 10);
+
+	      var old = container.style.display,
+	          height = void 0;
+
+	      container.style.display = 'block';
+	      height = ((0, _height2.default)(content) || 0) + (isNaN(margin) ? 0 : margin);
+	      container.style.display = old;
+	      return height;
+	    }, _this.isTransitioning = function () {
+	      return _this.state.status === OPENING || _this.state.status === CLOSED;
+	    }, _this.animate = function (el, props, dur, easing, cb) {
+	      _this._transition = _configuration2.default.animate(el, props, dur, easing, _this.setNextCallback(cb));
+	    }, _this.cancelNextCallback = function () {
+	      if (_this._transition && _this._transition.cancel) {
+	        _this._transition.cancel();
+	        _this._transition = null;
+	      }
+	      if (_this.nextCallback) {
+	        _this.nextCallback.cancel();
+	        _this.nextCallback = null;
+	      }
+	    }, _this.safeSetState = function (nextState, callback) {
+	      _this.setState(nextState, _this.setNextCallback(callback));
+	    }, _this.setNextCallback = function (callback) {
+	      var active = true;
+
+	      _this.nextCallback = function (event) {
+	        if (active) {
+	          active = false;
+	          _this.nextCallback = null;
+	          callback(event);
+	        }
+	      };
+
+	      _this.nextCallback.cancel = function () {
+	        return active = false;
+	      };
+	      return _this.nextCallback;
+	    }, _temp), _possibleConstructorReturn(_this, _ret);
+	  }
+
+	  _default.prototype.componentWillReceiveProps = function componentWillReceiveProps(nextProps) {
 	    this.setState({
 	      contentChanged: childKey(nextProps.children) !== childKey(this.props.children)
 	    });
-	  },
-	  componentDidMount: function componentDidMount() {
-	    var _this = this;
+	  };
+
+	  _default.prototype.componentDidMount = function componentDidMount() {
+	    var _this2 = this;
 
 	    var isOpen = this.state.status === OPENING;
 
 	    _compat2.default.batchedUpdates(function () {
-	      _this.setState({ initialRender: false });
+	      _this2.setState({ initialRender: false });
 	      if (isOpen) {
-	        _this.open();
+	        _this2.open();
 	      }
 	    });
-	  },
-	  componentDidUpdate: function componentDidUpdate(pvProps) {
+	  };
+
+	  _default.prototype.componentDidUpdate = function componentDidUpdate(pvProps) {
 	    var closing = pvProps.open && !this.props.open,
 	        opening = !pvProps.open && this.props.open,
 	        open = this.props.open,
@@ -2415,8 +4625,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	          diff = Math.abs(height - this.state.height);
 	      if (isNaN(diff) || diff > 0.1) this.setState({ height: height });
 	    }
-	  },
-	  render: function render() {
+	  };
+
+	  _default.prototype.render = function render() {
 	    var _props = this.props,
 	        className = _props.className,
 	        dropUp = _props.dropUp,
@@ -2441,120 +4652,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	      },
 	      this.renderChildren()
 	    );
-	  },
-	  renderChildren: function renderChildren() {
-	    if (!this.props.children) return _react2.default.createElement('span', { className: 'rw-popup rw-widget' });
+	  };
 
-	    var offset = this.getOffsetForStatus(this.state.status),
-	        child = _react2.default.Children.only(this.props.children);
+	  return _default;
+	}(_react2.default.Component), _class.displayName = 'Popup', _class.propTypes = propTypes, _class.defaultProps = {
+	  duration: 200,
+	  open: false,
+	  onClosing: function onClosing() {},
+	  onOpening: function onOpening() {},
+	  onClose: function onClose() {},
+	  onOpen: function onOpen() {}
+	}, _temp2);
 
-	    return (0, _react.cloneElement)(child, {
-	      style: _extends({}, child.props.style, offset, {
-	        position: this.isTransitioning() ? 'absolute' : undefined
-	      }),
-	      className: (0, _classnames2.default)(child.props.className, 'rw-popup rw-widget')
-	    });
-	  },
-	  open: function open() {
-	    var _this2 = this;
-
-	    this.cancelNextCallback();
-	    var el = _compat2.default.findDOMNode(this).firstChild,
-	        height = this.height();
-
-	    this.props.onOpening();
-
-	    this.safeSetState({ status: OPENING, height: height }, function () {
-	      var offset = _this2.getOffsetForStatus(OPEN),
-	          duration = _this2.props.duration;
-
-	      _this2.animate(el, offset, duration, 'ease', function () {
-	        _this2.safeSetState({ status: OPEN }, function () {
-	          _this2.props.onOpen();
-	        });
-	      });
-	    });
-	  },
-	  close: function close() {
-	    var _this3 = this;
-
-	    this.cancelNextCallback();
-	    var el = _compat2.default.findDOMNode(this).firstChild,
-	        height = this.height();
-
-	    this.props.onClosing();
-
-	    this.safeSetState({ status: CLOSING, height: height }, function () {
-	      var offset = _this3.getOffsetForStatus(CLOSED),
-	          duration = _this3.props.duration;
-
-	      _this3.animate(el, offset, duration, 'ease', function () {
-	        return _this3.safeSetState({ status: CLOSED }, function () {
-	          _this3.props.onClose();
-	        });
-	      });
-	    });
-	  },
-	  getOffsetForStatus: function getOffsetForStatus(status) {
-	    var _CLOSED$CLOSING$OPENI;
-
-	    if (this.state.initialRender) return {};
-
-	    var _in = properties('top', this.props.dropUp ? '100%' : '-100%'),
-	        out = properties('top', 0);
-	    return (_CLOSED$CLOSING$OPENI = {}, _CLOSED$CLOSING$OPENI[CLOSED] = _in, _CLOSED$CLOSING$OPENI[CLOSING] = out, _CLOSED$CLOSING$OPENI[OPENING] = _in, _CLOSED$CLOSING$OPENI[OPEN] = out, _CLOSED$CLOSING$OPENI)[status] || {};
-	  },
-	  height: function height() {
-	    var container = _compat2.default.findDOMNode(this),
-	        content = container.firstChild,
-	        margin = parseInt((0, _style2.default)(content, 'margin-top'), 10) + parseInt((0, _style2.default)(content, 'margin-bottom'), 10);
-
-	    var old = container.style.display,
-	        height = void 0;
-
-	    container.style.display = 'block';
-	    height = ((0, _height2.default)(content) || 0) + (isNaN(margin) ? 0 : margin);
-	    container.style.display = old;
-	    return height;
-	  },
-	  isTransitioning: function isTransitioning() {
-	    return this.state.status === OPENING || this.state.status === CLOSED;
-	  },
-	  animate: function animate(el, props, dur, easing, cb) {
-	    this._transition = _configuration2.default.animate(el, props, dur, easing, this.setNextCallback(cb));
-	  },
-	  cancelNextCallback: function cancelNextCallback() {
-	    if (this._transition && this._transition.cancel) {
-	      this._transition.cancel();
-	      this._transition = null;
-	    }
-	    if (this.nextCallback) {
-	      this.nextCallback.cancel();
-	      this.nextCallback = null;
-	    }
-	  },
-	  safeSetState: function safeSetState(nextState, callback) {
-	    this.setState(nextState, this.setNextCallback(callback));
-	  },
-	  setNextCallback: function setNextCallback(callback) {
-	    var _this4 = this;
-
-	    var active = true;
-
-	    this.nextCallback = function (event) {
-	      if (active) {
-	        active = false;
-	        _this4.nextCallback = null;
-	        callback(event);
-	      }
-	    };
-
-	    this.nextCallback.cancel = function () {
-	      return active = false;
-	    };
-	    return this.nextCallback;
-	  }
-	});
+	exports.default = _default;
 
 
 	function childKey(children) {
@@ -2567,28 +4677,28 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	module.exports = exports['default'];
 
-/***/ },
-/* 35 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 46 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	var offset = __webpack_require__(36),
-	    getWindow = __webpack_require__(37);
+	var offset = __webpack_require__(47),
+	    getWindow = __webpack_require__(48);
 
 	module.exports = function height(node, client) {
 	  var win = getWindow(node);
 	  return win ? win.innerHeight : client ? node.clientHeight : offset(node).height;
 	};
 
-/***/ },
-/* 36 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 47 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
-	var contains = __webpack_require__(24),
-	    getWindow = __webpack_require__(37),
-	    ownerDocument = __webpack_require__(23);
+	var contains = __webpack_require__(35),
+	    getWindow = __webpack_require__(48),
+	    ownerDocument = __webpack_require__(34);
 
 	module.exports = function offset(node) {
 	  var doc = ownerDocument(node),
@@ -2616,9 +4726,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return box;
 	};
 
-/***/ },
-/* 37 */
-/***/ function(module, exports) {
+/***/ }),
+/* 48 */
+/***/ (function(module, exports) {
 
 	'use strict';
 
@@ -2626,17 +4736,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return node === node.window ? node : node.nodeType === 9 ? node.defaultView || node.parentWindow : false;
 	};
 
-/***/ },
-/* 38 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 49 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	var _react = __webpack_require__(20);
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _reactDom = __webpack_require__(39);
+	var _reactDom = __webpack_require__(50);
 
 	var _reactDom2 = _interopRequireDefault(_reactDom);
 
@@ -2656,15 +4766,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-/***/ },
-/* 39 */
-/***/ function(module, exports) {
+/***/ }),
+/* 50 */
+/***/ (function(module, exports) {
 
-	module.exports = __WEBPACK_EXTERNAL_MODULE_39__;
+	module.exports = __WEBPACK_EXTERNAL_MODULE_50__;
 
-/***/ },
-/* 40 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 51 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -2672,23 +4782,31 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
-
-	var _react2 = _interopRequireDefault(_react);
-
-	var _ListOption = __webpack_require__(41);
-
-	var _ListOption2 = _interopRequireDefault(_ListOption);
-
-	var _propTypes = __webpack_require__(31);
+	var _propTypes = __webpack_require__(20);
 
 	var _propTypes2 = _interopRequireDefault(_propTypes);
 
-	var _compat = __webpack_require__(38);
+	var _react = __webpack_require__(29);
+
+	var _react2 = _interopRequireDefault(_react);
+
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+	var _ListOption = __webpack_require__(52);
+
+	var _ListOption2 = _interopRequireDefault(_ListOption);
+
+	var _propTypes3 = __webpack_require__(42);
+
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
+
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
-	var _classnames = __webpack_require__(25);
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
@@ -2696,11 +4814,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _dataHelpers = __webpack_require__(33);
+	var _dataHelpers = __webpack_require__(44);
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
-	var _interaction = __webpack_require__(43);
+	var _interaction = __webpack_require__(54);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2708,30 +4826,30 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return id + '__option__' + idx;
 	};
 
-	exports.default = _react2.default.createClass({
+	exports.default = (0, _createReactClass2.default)({
 
 	  displayName: 'List',
 
-	  mixins: [__webpack_require__(44), __webpack_require__(45)()],
+	  mixins: [__webpack_require__(55), __webpack_require__(56)()],
 
 	  propTypes: {
-	    data: _react2.default.PropTypes.array,
-	    onSelect: _react2.default.PropTypes.func,
-	    onMove: _react2.default.PropTypes.func,
+	    data: _propTypes2.default.array,
+	    onSelect: _propTypes2.default.func,
+	    onMove: _propTypes2.default.func,
 
-	    optionComponent: _propTypes2.default.elementType,
-	    itemComponent: _propTypes2.default.elementType,
+	    optionComponent: _propTypes4.default.elementType,
+	    itemComponent: _propTypes4.default.elementType,
 
-	    selected: _react2.default.PropTypes.any,
-	    focused: _react2.default.PropTypes.any,
-	    valueField: _propTypes2.default.accessor,
-	    textField: _propTypes2.default.accessor,
+	    selected: _propTypes2.default.any,
+	    focused: _propTypes2.default.any,
+	    valueField: _propTypes4.default.accessor,
+	    textField: _propTypes4.default.accessor,
 
-	    disabled: _propTypes2.default.disabled.acceptsArray,
-	    readOnly: _propTypes2.default.readOnly.acceptsArray,
+	    disabled: _propTypes4.default.disabled.acceptsArray,
+	    readOnly: _propTypes4.default.readOnly.acceptsArray,
 
-	    messages: _react2.default.PropTypes.shape({
-	      emptyList: _propTypes2.default.message
+	    messages: _propTypes2.default.shape({
+	      emptyList: _propTypes4.default.message
 	    })
 	  },
 
@@ -2840,9 +4958,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	module.exports = exports['default'];
 
-/***/ },
-/* 41 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 52 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -2850,11 +4968,17 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
+	var _class, _temp;
+
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _classnames = __webpack_require__(25);
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
@@ -2864,18 +4988,22 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-	var ListOption = _react2.default.createClass({
-	  displayName: 'ListOption',
+	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-	  propTypes: {
-	    dataItem: _react2.default.PropTypes.any,
-	    focused: _react2.default.PropTypes.bool,
-	    selected: _react2.default.PropTypes.bool,
-	    disabled: _react2.default.PropTypes.bool,
-	    readOnly: _react2.default.PropTypes.bool
-	  },
+	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-	  render: function render() {
+	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+	var ListOption = (_temp = _class = function (_React$Component) {
+	  _inherits(ListOption, _React$Component);
+
+	  function ListOption() {
+	    _classCallCheck(this, ListOption);
+
+	    return _possibleConstructorReturn(this, _React$Component.apply(this, arguments));
+	  }
+
+	  ListOption.prototype.render = function render() {
 	    var _props = this.props,
 	        className = _props.className,
 	        children = _props.children,
@@ -2904,15 +5032,22 @@ return /******/ (function(modules) { // webpackBootstrap
 	      }, props),
 	      children
 	    );
-	  }
-	});
+	  };
 
+	  return ListOption;
+	}(_react2.default.Component), _class.propTypes = {
+	  dataItem: _propTypes2.default.any,
+	  focused: _propTypes2.default.bool,
+	  selected: _propTypes2.default.bool,
+	  disabled: _propTypes2.default.bool,
+	  readOnly: _propTypes2.default.bool
+	}, _temp);
 	exports.default = ListOption;
 	module.exports = exports['default'];
 
-/***/ },
-/* 42 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 53 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -2938,9 +5073,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return component._firstFocus || component.state.focused && (component._firstFocus = true);
 	}
 
-/***/ },
-/* 43 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 54 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -2953,7 +5088,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.contains = contains;
 	exports.move = move;
 
-	var _dataHelpers = __webpack_require__(33);
+	var _dataHelpers = __webpack_require__(44);
 
 	function isDisabled(props) {
 	  return props.disabled === true || props.disabled === 'disabled';
@@ -3015,25 +5150,25 @@ return /******/ (function(modules) { // webpackBootstrap
 	  };
 	}
 
-/***/ },
-/* 44 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 55 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
 
-	var _filter = __webpack_require__(32);
+	var _filter = __webpack_require__(43);
 
 	var _filter2 = _interopRequireDefault(_filter);
 
-	var _dataHelpers = __webpack_require__(33);
+	var _dataHelpers = __webpack_require__(44);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes = __webpack_require__(42);
 
 	var _propTypes2 = _interopRequireDefault(_propTypes);
 
-	var _interaction = __webpack_require__(43);
+	var _interaction = __webpack_require__(54);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -3099,9 +5234,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	module.exports = exports['default'];
 
-/***/ },
-/* 45 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 56 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -3113,7 +5248,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  return {
 	    propTypes: {
-	      ariaActiveDescendantKey: _react2.default.PropTypes.string.isRequired
+	      ariaActiveDescendantKey: _propTypes2.default.string.isRequired
 	    },
 
 	    contextTypes: {
@@ -3155,19 +5290,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	  };
 	};
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _compat = __webpack_require__(38);
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-	var shape = _react2.default.PropTypes.shape({
+	var shape = _propTypes2.default.shape({
 	  //setActive: React.PropTypes.func,
-	  reconcile: _react2.default.PropTypes.func
+	  reconcile: _propTypes2.default.func
 	});
 
 	function defaultReconcile(key, id) {
@@ -3184,9 +5323,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = exports['default'];
 
-/***/ },
-/* 46 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 57 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -3194,23 +5333,31 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
-
-	var _react2 = _interopRequireDefault(_react);
-
-	var _ListOption = __webpack_require__(41);
-
-	var _ListOption2 = _interopRequireDefault(_ListOption);
-
-	var _propTypes = __webpack_require__(31);
+	var _propTypes = __webpack_require__(20);
 
 	var _propTypes2 = _interopRequireDefault(_propTypes);
 
-	var _compat = __webpack_require__(38);
+	var _react = __webpack_require__(29);
+
+	var _react2 = _interopRequireDefault(_react);
+
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+	var _ListOption = __webpack_require__(52);
+
+	var _ListOption2 = _interopRequireDefault(_ListOption);
+
+	var _propTypes3 = __webpack_require__(42);
+
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
+
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
-	var _classnames = __webpack_require__(25);
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
@@ -3218,15 +5365,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _warning = __webpack_require__(47);
+	var _warning = __webpack_require__(58);
 
 	var _warning2 = _interopRequireDefault(_warning);
 
-	var _dataHelpers = __webpack_require__(33);
+	var _dataHelpers = __webpack_require__(44);
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
-	var _interaction = __webpack_require__(43);
+	var _interaction = __webpack_require__(54);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -3234,34 +5381,34 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return id + '__option__' + idx;
 	};
 
-	exports.default = _react2.default.createClass({
+	exports.default = (0, _createReactClass2.default)({
 
 	  displayName: 'List',
 
-	  mixins: [__webpack_require__(44), __webpack_require__(45)()],
+	  mixins: [__webpack_require__(55), __webpack_require__(56)()],
 
 	  propTypes: {
-	    data: _react2.default.PropTypes.array,
-	    onSelect: _react2.default.PropTypes.func,
-	    onMove: _react2.default.PropTypes.func,
+	    data: _propTypes2.default.array,
+	    onSelect: _propTypes2.default.func,
+	    onMove: _propTypes2.default.func,
 
-	    optionComponent: _propTypes2.default.elementType,
-	    itemComponent: _propTypes2.default.elementType,
-	    groupComponent: _propTypes2.default.elementType,
+	    optionComponent: _propTypes4.default.elementType,
+	    itemComponent: _propTypes4.default.elementType,
+	    groupComponent: _propTypes4.default.elementType,
 
-	    selected: _react2.default.PropTypes.any,
-	    focused: _react2.default.PropTypes.any,
+	    selected: _propTypes2.default.any,
+	    focused: _propTypes2.default.any,
 
-	    valueField: _propTypes2.default.accessor,
-	    textField: _propTypes2.default.accessor,
+	    valueField: _propTypes4.default.accessor,
+	    textField: _propTypes4.default.accessor,
 
-	    disabled: _propTypes2.default.disabled.acceptsArray,
-	    readOnly: _propTypes2.default.readOnly.acceptsArray,
+	    disabled: _propTypes4.default.disabled.acceptsArray,
+	    readOnly: _propTypes4.default.readOnly.acceptsArray,
 
-	    groupBy: _propTypes2.default.accessor,
+	    groupBy: _propTypes4.default.accessor,
 
-	    messages: _react2.default.PropTypes.shape({
-	      emptyList: _propTypes2.default.message
+	    messages: _propTypes2.default.shape({
+	      emptyList: _propTypes4.default.message
 	    })
 	  },
 
@@ -3462,9 +5609,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	module.exports = exports['default'];
 
-/***/ },
-/* 47 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 58 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {/**
 	 * Copyright 2014-2015, Facebook, Inc.
@@ -3529,9 +5676,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
-/***/ },
-/* 48 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 59 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {'use strict';
 
@@ -3556,15 +5703,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports['default'];
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
-/***/ },
-/* 49 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 60 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
 
-	var _createUncontrollable = __webpack_require__(50);
+	var _createUncontrollable = __webpack_require__(61);
 
 	var _createUncontrollable2 = _interopRequireDefault(_createUncontrollable);
 
@@ -3586,15 +5733,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  component._values[propName] = value;
 
-	  if (component.isMounted()) component.forceUpdate();
+	  if (!component.unmounted) component.forceUpdate();
 	}
 
-	exports.default = (0, _createUncontrollable2.default)([mixin], set);
+	exports.default = (0, _createUncontrollable2.default)(mixin, set);
 	module.exports = exports['default'];
 
-/***/ },
-/* 50 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 61 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -3604,7 +5751,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	exports.default = createUncontrollable;
 
-	var _react = __webpack_require__(20);
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
@@ -3612,7 +5759,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _invariant2 = _interopRequireDefault(_invariant);
 
-	var _utils = __webpack_require__(51);
+	var _utils = __webpack_require__(62);
 
 	var utils = _interopRequireWildcard(_utils);
 
@@ -3620,12 +5767,20 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-	function createUncontrollable(mixins, set) {
+	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+	function createUncontrollable(mixin, set) {
 
 	  return uncontrollable;
 
 	  function uncontrollable(Component, controlledValues) {
-	    var methods = arguments.length <= 2 || arguments[2] === undefined ? [] : arguments[2];
+	    var _class, _temp;
+
+	    var methods = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : [];
 
 	    var displayName = Component.displayName || Component.name || 'Component',
 	        basePropTypes = utils.getType(Component).propTypes,
@@ -3647,63 +5802,82 @@ return /******/ (function(modules) { // webpackBootstrap
 	      };
 	    }, {});
 
-	    var component = _react2.default.createClass(_extends({
+	    var component = (_temp = _class = function (_React$Component) {
+	      _inherits(component, _React$Component);
 
-	      displayName: 'Uncontrolled(' + displayName + ')',
+	      function component() {
+	        _classCallCheck(this, component);
 
-	      mixins: mixins,
+	        return _possibleConstructorReturn(this, _React$Component.apply(this, arguments));
+	      }
 
-	      propTypes: propTypes
+	      component.prototype.shouldComponentUpdate = function shouldComponentUpdate() {
+	        for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+	          args[_key] = arguments[_key];
+	        }
 
-	    }, methods, {
-	      componentWillMount: function componentWillMount() {
-	        var _this = this;
+	        return !mixin.shouldComponentUpdate || mixin.shouldComponentUpdate.apply(this, args);
+	      };
+
+	      component.prototype.componentWillMount = function componentWillMount() {
+	        var _this2 = this;
 
 	        var props = this.props;
 
 	        this._values = {};
 
 	        controlledProps.forEach(function (key) {
-	          _this._values[key] = props[utils.defaultKey(key)];
+	          _this2._values[key] = props[utils.defaultKey(key)];
 	        });
-	      },
-
+	      };
 
 	      /**
 	       * If a prop switches from controlled to Uncontrolled
 	       * reset its value to the defaultValue
 	       */
-	      componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
-	        var _this2 = this;
+
+
+	      component.prototype.componentWillReceiveProps = function componentWillReceiveProps(nextProps) {
+	        var _this3 = this;
 
 	        var props = this.props;
 
+	        if (mixin.componentWillReceiveProps) {
+	          mixin.componentWillReceiveProps.call(this, nextProps);
+	        }
+
 	        controlledProps.forEach(function (key) {
 	          if (utils.getValue(nextProps, key) === undefined && utils.getValue(props, key) !== undefined) {
-	            _this2._values[key] = nextProps[utils.defaultKey(key)];
+	            _this3._values[key] = nextProps[utils.defaultKey(key)];
 	          }
 	        });
-	      },
-	      getControlledInstance: function getControlledInstance() {
+	      };
+
+	      component.prototype.componentWillUnmount = function componentWillUnmount() {
+	        this.unmounted = true;
+	      };
+
+	      component.prototype.getControlledInstance = function getControlledInstance() {
 	        return this.refs.inner;
-	      },
-	      render: function render() {
-	        var _this3 = this;
+	      };
+
+	      component.prototype.render = function render() {
+	        var _this4 = this;
 
 	        var newProps = {},
 	            props = omitProps(this.props);
 
 	        utils.each(controlledValues, function (handle, propName) {
 	          var linkPropName = utils.getLinkName(propName),
-	              prop = _this3.props[propName];
+	              prop = _this4.props[propName];
 
-	          if (linkPropName && !isProp(_this3.props, propName) && isProp(_this3.props, linkPropName)) {
-	            prop = _this3.props[linkPropName].value;
+	          if (linkPropName && !isProp(_this4.props, propName) && isProp(_this4.props, linkPropName)) {
+	            prop = _this4.props[linkPropName].value;
 	          }
 
-	          newProps[propName] = prop !== undefined ? prop : _this3._values[propName];
+	          newProps[propName] = prop !== undefined ? prop : _this4._values[propName];
 
-	          newProps[handle] = setAndNotify.bind(_this3, propName);
+	          newProps[handle] = setAndNotify.bind(_this4, propName);
 	        });
 
 	        newProps = _extends({}, props, newProps, {
@@ -3711,8 +5885,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	        });
 
 	        return _react2.default.createElement(Component, newProps);
-	      }
-	    }));
+	      };
+
+	      return component;
+	    }(_react2.default.Component), _class.displayName = 'Uncontrolled(' + displayName + ')', _class.propTypes = propTypes, _temp);
+
+	    _extends(component.prototype, methods);
 
 	    component.ControlledComponent = Component;
 
@@ -3721,7 +5899,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	     * everything
 	     */
 	    component.deferControlTo = function (newComponent) {
-	      var additions = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+	      var additions = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 	      var nextMethods = arguments[2];
 
 	      return uncontrollable(newComponent, _extends({}, controlledValues, additions), nextMethods);
@@ -3737,8 +5915,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	        handler = this.props[linkName].requestChange;
 	      }
 
-	      for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
-	        args[_key - 2] = arguments[_key];
+	      for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+	        args[_key2 - 2] = arguments[_key2];
 	      }
 
 	      set(this, propName, handler, value, args);
@@ -3761,9 +5939,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	module.exports = exports['default'];
 
-/***/ },
-/* 51 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 62 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {'use strict';
 
@@ -3780,7 +5958,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.has = has;
 	exports.isReactComponent = isReactComponent;
 
-	var _react = __webpack_require__(20);
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
@@ -3883,9 +6061,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
-/***/ },
-/* 52 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 63 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -3920,25 +6098,29 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-/***/ },
-/* 53 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 64 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _reactDom = __webpack_require__(39);
+	var _reactDom = __webpack_require__(50);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 	exports.default = {
 	  propTypes: {
-	    autoFocus: _react2.default.PropTypes.bool
+	    autoFocus: _propTypes2.default.bool
 	  },
 
 	  componentDidMount: function componentDidMount() {
@@ -3950,9 +6132,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 	module.exports = exports['default'];
 
-/***/ },
-/* 54 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 65 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -3965,25 +6147,29 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-/***/ },
-/* 55 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 66 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	var _react = __webpack_require__(20);
-
-	var _react2 = _interopRequireDefault(_react);
-
-	var _filter = __webpack_require__(32);
-
-	var _filter2 = _interopRequireDefault(_filter);
-
-	var _propTypes = __webpack_require__(31);
+	var _propTypes = __webpack_require__(20);
 
 	var _propTypes2 = _interopRequireDefault(_propTypes);
 
-	var _dataHelpers = __webpack_require__(33);
+	var _react = __webpack_require__(29);
+
+	var _react2 = _interopRequireDefault(_react);
+
+	var _filter = __webpack_require__(43);
+
+	var _filter2 = _interopRequireDefault(_filter);
+
+	var _propTypes3 = __webpack_require__(42);
+
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
+
+	var _dataHelpers = __webpack_require__(44);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -3994,11 +6180,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = {
 
 	  propTypes: {
-	    data: _react2.default.PropTypes.array,
-	    value: _react2.default.PropTypes.any,
-	    filter: _propTypes2.default.filter,
-	    caseSensitive: _react2.default.PropTypes.bool,
-	    minLength: _react2.default.PropTypes.number
+	    data: _propTypes2.default.array,
+	    value: _propTypes2.default.any,
+	    filter: _propTypes4.default.filter,
+	    caseSensitive: _propTypes2.default.bool,
+	    minLength: _propTypes2.default.number
 	  },
 
 	  getDefaultProps: function getDefaultProps() {
@@ -4044,15 +6230,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	  };
 	}
 
-/***/ },
-/* 56 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 67 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
 
-	var _scrollTo2 = __webpack_require__(57);
+	var _scrollTo2 = __webpack_require__(68);
 
 	var _scrollTo3 = _interopRequireDefault(_scrollTo2);
 
@@ -4083,17 +6269,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 	module.exports = exports['default'];
 
-/***/ },
-/* 57 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 68 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
-	var getOffset = __webpack_require__(36),
-	    height = __webpack_require__(35),
-	    getScrollParent = __webpack_require__(58),
-	    scrollTop = __webpack_require__(59),
-	    raf = __webpack_require__(60),
-	    getWindow = __webpack_require__(37);
+	var getOffset = __webpack_require__(47),
+	    height = __webpack_require__(46),
+	    getScrollParent = __webpack_require__(69),
+	    scrollTop = __webpack_require__(70),
+	    raf = __webpack_require__(71),
+	    getWindow = __webpack_require__(48);
 
 	module.exports = function scrollTo(selected, scrollParent) {
 	    var offset = getOffset(selected),
@@ -4139,14 +6325,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 	};
 
-/***/ },
-/* 58 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 69 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	var css = __webpack_require__(6),
-	    height = __webpack_require__(35);
+	    height = __webpack_require__(46);
 
 	module.exports = function scrollPrarent(node) {
 	  var position = css(node, 'position'),
@@ -4168,12 +6354,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return document;
 	};
 
-/***/ },
-/* 59 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 70 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
-	var getWindow = __webpack_require__(37);
+	var getWindow = __webpack_require__(48);
 
 	module.exports = function scrollTop(node, val) {
 	  var win = getWindow(node);
@@ -4183,9 +6369,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  if (win) win.scrollTo('pageXOffset' in win ? win.pageXOffset : win.document.documentElement.scrollLeft, val);else node.scrollTop = val;
 	};
 
-/***/ },
-/* 60 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 71 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -4234,26 +6420,27 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = compatRaf;
 
-/***/ },
-/* 61 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 72 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	var React = __webpack_require__(20);
+	var PropTypes = __webpack_require__(20);
+	var React = __webpack_require__(29);
 
 	module.exports = {
 
 	  propTypes: {
-	    isRtl: React.PropTypes.bool
+	    isRtl: PropTypes.bool
 	  },
 
 	  contextTypes: {
-	    isRtl: React.PropTypes.bool
+	    isRtl: PropTypes.bool
 	  },
 
 	  childContextTypes: {
-	    isRtl: React.PropTypes.bool
+	    isRtl: PropTypes.bool
 	  },
 
 	  getChildContext: function getChildContext() {
@@ -4266,20 +6453,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-/***/ },
-/* 62 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 73 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
 	exports.default = FocusMixin;
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
-	var _interaction = __webpack_require__(43);
+	var _interaction = __webpack_require__(54);
 
-	var _compat = __webpack_require__(38);
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
@@ -4350,9 +6537,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	module.exports = exports['default'];
 
-/***/ },
-/* 63 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 74 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -4362,11 +6549,19 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _classnames = __webpack_require__(25);
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
@@ -4374,55 +6569,55 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _filter = __webpack_require__(32);
+	var _filter = __webpack_require__(43);
 
 	var _filter2 = _interopRequireDefault(_filter);
 
-	var _Widget = __webpack_require__(26);
+	var _Widget = __webpack_require__(37);
 
 	var _Widget2 = _interopRequireDefault(_Widget);
 
-	var _Popup = __webpack_require__(34);
+	var _Popup = __webpack_require__(45);
 
 	var _Popup2 = _interopRequireDefault(_Popup);
 
-	var _Select = __webpack_require__(28);
+	var _Select = __webpack_require__(39);
 
 	var _Select2 = _interopRequireDefault(_Select);
 
-	var _ComboboxInput = __webpack_require__(64);
+	var _ComboboxInput = __webpack_require__(75);
 
 	var _ComboboxInput2 = _interopRequireDefault(_ComboboxInput);
 
-	var _compat = __webpack_require__(38);
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
-	var _List = __webpack_require__(40);
+	var _List = __webpack_require__(51);
 
 	var _List2 = _interopRequireDefault(_List);
 
-	var _ListGroupable = __webpack_require__(46);
+	var _ListGroupable = __webpack_require__(57);
 
 	var _ListGroupable2 = _interopRequireDefault(_ListGroupable);
 
-	var _validateListInterface = __webpack_require__(48);
+	var _validateListInterface = __webpack_require__(59);
 
 	var _validateListInterface2 = _interopRequireDefault(_validateListInterface);
 
-	var _uncontrollable = __webpack_require__(49);
+	var _uncontrollable = __webpack_require__(60);
 
 	var _uncontrollable2 = _interopRequireDefault(_uncontrollable);
 
-	var _dataHelpers = __webpack_require__(33);
+	var _dataHelpers = __webpack_require__(44);
 
-	var _interaction = __webpack_require__(43);
+	var _interaction = __webpack_require__(54);
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -4462,52 +6657,52 @@ return /******/ (function(modules) { // webpackBootstrap
 	var propTypes = _extends({}, _Popup2.default.propTypes, {
 
 	  //-- controlled props -----------
-	  value: _react2.default.PropTypes.any,
-	  onChange: _react2.default.PropTypes.func,
-	  open: _react2.default.PropTypes.bool,
-	  onToggle: _react2.default.PropTypes.func,
+	  value: _propTypes2.default.any,
+	  onChange: _propTypes2.default.func,
+	  open: _propTypes2.default.bool,
+	  onToggle: _propTypes2.default.func,
 	  //------------------------------------
 
-	  itemComponent: _propTypes2.default.elementType,
-	  listComponent: _propTypes2.default.elementType,
+	  itemComponent: _propTypes4.default.elementType,
+	  listComponent: _propTypes4.default.elementType,
 
-	  groupComponent: _propTypes2.default.elementType,
-	  groupBy: _propTypes2.default.accessor,
+	  groupComponent: _propTypes4.default.elementType,
+	  groupBy: _propTypes4.default.accessor,
 
-	  data: _react2.default.PropTypes.array,
-	  valueField: _react2.default.PropTypes.string,
-	  textField: _propTypes2.default.accessor,
-	  name: _react2.default.PropTypes.string,
+	  data: _propTypes2.default.array,
+	  valueField: _propTypes2.default.string,
+	  textField: _propTypes4.default.accessor,
+	  name: _propTypes2.default.string,
 
-	  onSelect: _react2.default.PropTypes.func,
+	  onSelect: _propTypes2.default.func,
 
-	  autoFocus: _react2.default.PropTypes.bool,
-	  disabled: _propTypes2.default.disabled.acceptsArray,
-	  readOnly: _propTypes2.default.readOnly.acceptsArray,
+	  autoFocus: _propTypes2.default.bool,
+	  disabled: _propTypes4.default.disabled.acceptsArray,
+	  readOnly: _propTypes4.default.readOnly.acceptsArray,
 
-	  suggest: _propTypes2.default.filter,
-	  filter: _propTypes2.default.filter,
+	  suggest: _propTypes4.default.filter,
+	  filter: _propTypes4.default.filter,
 
-	  busy: _react2.default.PropTypes.bool,
+	  busy: _propTypes2.default.bool,
 
-	  dropUp: _react2.default.PropTypes.bool,
-	  duration: _react2.default.PropTypes.number,
-	  delay: _react2.default.PropTypes.number,
+	  dropUp: _propTypes2.default.bool,
+	  duration: _propTypes2.default.number,
+	  delay: _propTypes2.default.number,
 
-	  placeholder: _react2.default.PropTypes.string,
+	  placeholder: _propTypes2.default.string,
 
-	  messages: _react2.default.PropTypes.shape({
-	    open: _propTypes2.default.message,
-	    emptyList: _propTypes2.default.message,
-	    emptyFilter: _propTypes2.default.message
+	  messages: _propTypes2.default.shape({
+	    open: _propTypes4.default.message,
+	    emptyList: _propTypes4.default.message,
+	    emptyFilter: _propTypes4.default.message
 	  })
 	});
 
-	var ComboBox = _react2.default.createClass((_obj = {
+	var ComboBox = (0, _createReactClass2.default)((_obj = {
 
 	  displayName: 'ComboBox',
 
-	  mixins: [__webpack_require__(52), __webpack_require__(55), __webpack_require__(56), __webpack_require__(61), __webpack_require__(45)('input'), __webpack_require__(62)({
+	  mixins: [__webpack_require__(63), __webpack_require__(66), __webpack_require__(67), __webpack_require__(72), __webpack_require__(56)('input'), __webpack_require__(73)({
 	    willHandle: function willHandle(focused) {
 	      // not suggesting anymore
 	      !focused && this.refs.input.accept();
@@ -4724,119 +6919,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    (0, _widgetHelpers.notify)(this.props.onSelect, data);
 	    this.change(data);
 	    this.focus();
-	  },
-	  handleInputKeyDown: function handleInputKeyDown(e) {
-	    this._deleting = e.key === 'Backspace' || e.key === 'Delete';
-	    this._isTyping = true;
-	  },
-	  handleInputChange: function handleInputChange(e) {
-	    var _props5 = this.props,
-	        data = _props5.data,
-	        textField = _props5.textField;
-
-
-	    var shouldSuggest = !!this.props.suggest,
-	        strVal = e.target.value,
-	        suggestion;
-
-	    suggestion = this._deleting || !shouldSuggest ? strVal : this.suggest(this._data(), strVal);
-
-	    suggestion = suggestion || strVal;
-
-	    data = _3.default.find(data, function (item) {
-	      return (0, _dataHelpers.dataText)(item, textField).toLowerCase() === suggestion.toLowerCase();
-	    });
-
-	    this.change(!this._deleting && data ? data : strVal, true);
-
-	    this.open();
-	  },
-	  focus: function focus() {
-	    this.refs.input && this.refs.input.focus();
-	  },
-	  handleKeyDown: function handleKeyDown(e) {
-	    var self = this,
-	        key = e.key,
-	        alt = e.altKey,
-	        list = this.refs.list,
-	        focusedItem = this.state.focusedItem,
-	        selectedItem = this.state.selectedItem,
-	        isOpen = this.props.open;
-
-	    (0, _widgetHelpers.notify)(this.props.onKeyDown, [e]);
-	    if (e.defaultPrevented) return;
-
-	    if (key === 'End') {
-	      if (isOpen) this.setState({ focusedItem: list.last() });else select(list.last(), true);
-	    } else if (key === 'Home') {
-	      if (isOpen) this.setState({ focusedItem: list.first() });else select(list.first(), true);
-	    } else if (key === 'Escape' && isOpen) this.close();else if (key === 'Enter' && isOpen) {
-	      e.preventDefault();
-	      select(this.state.focusedItem, true);
-	    } else if (key === 'ArrowDown') {
-	      if (alt) this.open();else {
-	        if (isOpen) this.setState({ focusedItem: list.next(focusedItem) });else select(list.next(selectedItem), true);
-	      }
-	    } else if (key === 'ArrowUp') {
-	      if (alt) this.close();else {
-	        if (isOpen) this.setState({ focusedItem: list.prev(focusedItem) });else select(list.prev(selectedItem), true);
-	      }
-	    }
-
-	    function select(item, fromList) {
-	      if (!item) return self.change(_compat2.default.findDOMNode(self.refs.input).value, false);
-
-	      self.refs.input.accept(true); //removes caret
-
-	      if (fromList) return self.handleSelect(item);
-
-	      self.change(item, false);
-	    }
-	  },
-	  change: function change(data, typing) {
-	    this._typedChange = !!typing;
-	    (0, _widgetHelpers.notify)(this.props.onChange, data);
-	  },
-	  open: function open() {
-	    if (!this.props.open) (0, _widgetHelpers.notify)(this.props.onToggle, true);
-	  },
-	  close: function close() {
-	    if (this.props.open) (0, _widgetHelpers.notify)(this.props.onToggle, false);
-	  },
-	  toggle: function toggle() {
-	    this.focus();
-
-	    this.props.open ? this.close() : this.open();
-	  },
-	  suggest: function suggest(data, value) {
-	    var _props6 = this.props,
-	        textField = _props6.textField,
-	        suggest = _props6.suggest,
-	        minLength = _props6.minLength;
-
-
-	    var word = (0, _dataHelpers.dataText)(value, textField),
-	        suggestion;
-
-	    suggest = defaultSuggest(suggest);
-
-	    if (!(word || '').trim() || word.length < (minLength || 1)) return '';
-
-	    suggestion = typeof value === 'string' ? _3.default.find(data, getFilter(suggest, word, textField)) : value;
-
-	    if (suggestion && (!this.state || !this.state.deleting)) return (0, _dataHelpers.dataText)(suggestion, textField);
-
-	    return '';
-	  },
-	  _data: function _data() {
-	    return this.state.processedData;
-	  },
-	  process: function process(data, values, searchTerm) {
-	    if (this.props.filter && searchTerm) data = this.filter(data, searchTerm);
-
-	    return data;
 	  }
-	}, (_applyDecoratedDescriptor(_obj, 'handleSelect', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleSelect'), _obj), _applyDecoratedDescriptor(_obj, 'handleKeyDown', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleKeyDown'), _obj), _applyDecoratedDescriptor(_obj, 'toggle', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'toggle'), _obj)), _obj));
+	}, (_applyDecoratedDescriptor(_obj, 'handleSelect', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleSelect'), _obj)), _obj));
 
 	exports.default = (0, _uncontrollable2.default)(ComboBox, { open: 'onToggle', value: 'onChange' }, ['focus']);
 
@@ -4858,17 +6942,24 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	module.exports = exports['default'];
 
-/***/ },
-/* 64 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 75 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
+	exports.default = undefined;
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
+	var _class, _temp2;
+
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
@@ -4876,15 +6967,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _caret = __webpack_require__(65);
+	var _caret = __webpack_require__(76);
 
 	var _caret2 = _interopRequireDefault(_caret);
 
-	var _compat = __webpack_require__(38);
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
-	var _Input = __webpack_require__(27);
+	var _Input = __webpack_require__(38);
 
 	var _Input2 = _interopRequireDefault(_Input);
 
@@ -4892,17 +6983,51 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-	exports.default = _react2.default.createClass({
+	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-	  displayName: 'ComboboxInput',
+	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-	  propTypes: {
-	    value: _react2.default.PropTypes.string,
-	    suggest: _react2.default.PropTypes.bool,
-	    onChange: _react2.default.PropTypes.func.isRequired
-	  },
+	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-	  componentDidUpdate: function componentDidUpdate() {
+	var _default = (_temp2 = _class = function (_React$Component) {
+	  _inherits(_default, _React$Component);
+
+	  function _default() {
+	    var _temp, _this, _ret;
+
+	    _classCallCheck(this, _default);
+
+	    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+	      args[_key] = arguments[_key];
+	    }
+
+	    return _ret = (_temp = (_this = _possibleConstructorReturn(this, _React$Component.call.apply(_React$Component, [this].concat(args))), _this), _this.isSuggesting = function () {
+	      var val = _this.props.value,
+	          isSuggestion = _this._last != null && val.toLowerCase().indexOf(_this._last.toLowerCase()) !== -1;
+
+	      return _this.props.suggest && isSuggestion;
+	    }, _this.accept = function (removeCaret) {
+	      var val = _compat2.default.findDOMNode(_this).value || '',
+	          end = val.length;
+
+	      _this._last = null;
+	      removeCaret && (0, _caret2.default)(_compat2.default.findDOMNode(_this), end, end);
+	    }, _this.handleChange = function (e) {
+	      var val = e.target.value,
+	          pl = !!_this.props.placeholder;
+
+	      // IE fires input events when setting/unsetting placeholders.
+	      // issue #112
+	      if (pl && !val && val === (_this.props.value || '')) return;
+
+	      _this._last = val;
+	      _this.props.onChange(e, val);
+	    }, _this.focus = function () {
+	      _compat2.default.findDOMNode(_this).focus();
+	    }, _temp), _possibleConstructorReturn(_this, _ret);
+	  }
+
+	  _default.prototype.componentDidUpdate = function componentDidUpdate() {
 	    var input = _compat2.default.findDOMNode(this),
 	        val = this.props.value;
 
@@ -4914,13 +7039,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	        (0, _caret2.default)(input, start, start + end);
 	      }
 	    }
-	  },
-	  getDefaultProps: function getDefaultProps() {
-	    return {
-	      value: ''
-	    };
-	  },
-	  render: function render() {
+	  };
+
+	  _default.prototype.render = function render() {
 	    var _props = this.props,
 	        onKeyDown = _props.onKeyDown,
 	        props = _objectWithoutProperties(_props, ['onKeyDown']);
@@ -4931,40 +7052,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	      onKeyDown: onKeyDown,
 	      onChange: this.handleChange
 	    }));
-	  },
-	  isSuggesting: function isSuggesting() {
-	    var val = this.props.value,
-	        isSuggestion = this._last != null && val.toLowerCase().indexOf(this._last.toLowerCase()) !== -1;
+	  };
 
-	    return this.props.suggest && isSuggestion;
-	  },
-	  accept: function accept(removeCaret) {
-	    var val = _compat2.default.findDOMNode(this).value || '',
-	        end = val.length;
+	  return _default;
+	}(_react2.default.Component), _class.displayName = 'ComboboxInput', _class.propTypes = {
+	  value: _propTypes2.default.string,
+	  suggest: _propTypes2.default.bool,
+	  onChange: _propTypes2.default.func.isRequired
+	}, _class.defaultProps = {
+	  value: ''
+	}, _temp2);
 
-	    this._last = null;
-	    removeCaret && (0, _caret2.default)(_compat2.default.findDOMNode(this), end, end);
-	  },
-	  handleChange: function handleChange(e) {
-	    var val = e.target.value,
-	        pl = !!this.props.placeholder;
-
-	    // IE fires input events when setting/unsetting placeholders.
-	    // issue #112
-	    if (pl && !val && val === (this.props.value || '')) return;
-
-	    this._last = val;
-	    this.props.onChange(e, val);
-	  },
-	  focus: function focus() {
-	    _compat2.default.findDOMNode(this).focus();
-	  }
-	});
+	exports.default = _default;
 	module.exports = exports['default'];
 
-/***/ },
-/* 65 */
-/***/ function(module, exports) {
+/***/ }),
+/* 76 */
+/***/ (function(module, exports) {
 
 	'use strict';
 
@@ -5019,9 +7123,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	module.exports = exports['default'];
 
-/***/ },
-/* 66 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 77 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -5029,68 +7133,76 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _VIEW, _OPPOSITE_DIRECTION, _MULTIPLIER, _desc, _value2, _obj; //values, omit
+	var _VIEW, _OPPOSITE_DIRECTION, _MULTIPLIER, _desc, _value, _obj; //values, omit
 
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _classnames = __webpack_require__(25);
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
-	var _compat = __webpack_require__(38);
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
-	var _Widget = __webpack_require__(26);
+	var _Widget = __webpack_require__(37);
 
 	var _Widget2 = _interopRequireDefault(_Widget);
 
-	var _Header = __webpack_require__(67);
+	var _Header = __webpack_require__(78);
 
 	var _Header2 = _interopRequireDefault(_Header);
 
-	var _Footer = __webpack_require__(69);
+	var _Footer = __webpack_require__(80);
 
 	var _Footer2 = _interopRequireDefault(_Footer);
 
-	var _Month = __webpack_require__(70);
+	var _Month = __webpack_require__(81);
 
 	var _Month2 = _interopRequireDefault(_Month);
 
-	var _Year = __webpack_require__(75);
+	var _Year = __webpack_require__(86);
 
 	var _Year2 = _interopRequireDefault(_Year);
 
-	var _Decade = __webpack_require__(76);
+	var _Decade = __webpack_require__(87);
 
 	var _Decade2 = _interopRequireDefault(_Decade);
 
-	var _Century = __webpack_require__(77);
+	var _Century = __webpack_require__(88);
 
 	var _Century2 = _interopRequireDefault(_Century);
 
 	var _localizers = __webpack_require__(17);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
-	var _uncontrollable = __webpack_require__(49);
+	var _uncontrollable = __webpack_require__(60);
 
 	var _uncontrollable2 = _interopRequireDefault(_uncontrollable);
 
-	var _SlideTransition = __webpack_require__(78);
+	var _SlideTransition = __webpack_require__(89);
 
 	var _SlideTransition2 = _interopRequireDefault(_SlideTransition);
 
-	var _dates = __webpack_require__(72);
+	var _dates = __webpack_require__(83);
 
 	var _dates2 = _interopRequireDefault(_dates);
 
-	var _constants = __webpack_require__(74);
+	var _constants = __webpack_require__(85);
 
 	var constants = _interopRequireWildcard(_constants);
 
@@ -5098,15 +7210,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
-	var _interaction = __webpack_require__(43);
+	var _interaction = __webpack_require__(54);
 
 	function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-	function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
 	function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) {
 	  var desc = {};
@@ -5173,60 +7283,60 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var propTypes = {
 
-	  disabled: _propTypes2.default.disabled,
-	  readOnly: _propTypes2.default.readOnly,
+	  disabled: _propTypes4.default.disabled,
+	  readOnly: _propTypes4.default.readOnly,
 
-	  onChange: _react2.default.PropTypes.func,
-	  value: _react2.default.PropTypes.instanceOf(Date),
+	  onChange: _propTypes2.default.func,
+	  value: _propTypes2.default.instanceOf(Date),
 
-	  min: _react2.default.PropTypes.instanceOf(Date),
-	  max: _react2.default.PropTypes.instanceOf(Date),
+	  min: _propTypes2.default.instanceOf(Date),
+	  max: _propTypes2.default.instanceOf(Date),
 
-	  currentDate: _react2.default.PropTypes.instanceOf(Date),
-	  onCurrentDateChange: _react2.default.PropTypes.func,
+	  currentDate: _propTypes2.default.instanceOf(Date),
+	  onCurrentDateChange: _propTypes2.default.func,
 
-	  view: _react2.default.PropTypes.oneOf(VIEW_OPTIONS),
-	  initialView: _react2.default.PropTypes.oneOf(VIEW_OPTIONS),
+	  view: _propTypes2.default.oneOf(VIEW_OPTIONS),
+	  initialView: _propTypes2.default.oneOf(VIEW_OPTIONS),
 
 	  finalView: function finalView(props, propName, componentName) {
 	    for (var _len = arguments.length, args = Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
 	      args[_key - 3] = arguments[_key];
 	    }
 
-	    var err = _react2.default.PropTypes.oneOf(VIEW_OPTIONS).apply(undefined, [props, propName, componentName].concat(args));
+	    var err = _propTypes2.default.oneOf(VIEW_OPTIONS).apply(undefined, [props, propName, componentName].concat(args));
 
 	    if (err) return err;
 	    if (VIEW_OPTIONS.indexOf(props[propName]) < VIEW_OPTIONS.indexOf(props.initialView)) return new Error(('The `' + propName + '` prop: `' + props[propName] + '` cannot be \'lower\' than the `initialView`\n        prop. This creates a range that cannot be rendered.').replace(/\n\t/g, ''));
 	  },
 
 
-	  onViewChange: _react2.default.PropTypes.func,
-	  onNavigate: _react2.default.PropTypes.func,
-	  culture: _react2.default.PropTypes.string,
-	  footer: _react2.default.PropTypes.bool,
+	  onViewChange: _propTypes2.default.func,
+	  onNavigate: _propTypes2.default.func,
+	  culture: _propTypes2.default.string,
+	  footer: _propTypes2.default.bool,
 
-	  dayComponent: _propTypes2.default.elementType,
-	  headerFormat: _propTypes2.default.dateFormat,
-	  footerFormat: _propTypes2.default.dateFormat,
+	  dayComponent: _propTypes4.default.elementType,
+	  headerFormat: _propTypes4.default.dateFormat,
+	  footerFormat: _propTypes4.default.dateFormat,
 
-	  dayFormat: _propTypes2.default.dateFormat,
-	  dateFormat: _propTypes2.default.dateFormat,
-	  monthFormat: _propTypes2.default.dateFormat,
-	  yearFormat: _propTypes2.default.dateFormat,
-	  decadeFormat: _propTypes2.default.dateFormat,
-	  centuryFormat: _propTypes2.default.dateFormat,
+	  dayFormat: _propTypes4.default.dateFormat,
+	  dateFormat: _propTypes4.default.dateFormat,
+	  monthFormat: _propTypes4.default.dateFormat,
+	  yearFormat: _propTypes4.default.dateFormat,
+	  decadeFormat: _propTypes4.default.dateFormat,
+	  centuryFormat: _propTypes4.default.dateFormat,
 
-	  messages: _react2.default.PropTypes.shape({
-	    moveBack: _react2.default.PropTypes.string,
-	    moveForward: _react2.default.PropTypes.string
+	  messages: _propTypes2.default.shape({
+	    moveBack: _propTypes2.default.string,
+	    moveForward: _propTypes2.default.string
 	  })
 	};
 
-	var Calendar = _react2.default.createClass((_obj = {
+	var Calendar = (0, _createReactClass2.default)((_obj = {
 
 	  displayName: 'Calendar',
 
-	  mixins: [__webpack_require__(52), __webpack_require__(53), __webpack_require__(54), __webpack_require__(61), __webpack_require__(45)(), __webpack_require__(62)({
+	  mixins: [__webpack_require__(63), __webpack_require__(64), __webpack_require__(65), __webpack_require__(72), __webpack_require__(56)(), __webpack_require__(73)({
 	    willHandle: function willHandle() {
 	      if (+this.props.tabIndex === -1) return false;
 	    }
@@ -5407,97 +7517,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    this.navigate(dir.DOWN, date);
-	  },
-	  changeCurrentDate: function changeCurrentDate(date) {
-	    var currentDate = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : this.props.currentDate;
-
-	    var inRangeDate = this.inRangeValue(date ? new Date(date) : currentDate);
-	    if (_dates2.default.eq(inRangeDate, dateOrNull(currentDate), VIEW_UNIT[this.state.view])) return;
-	    (0, _widgetHelpers.notify)(this.props.onCurrentDateChange, inRangeDate);
-	  },
-	  select: function select(date) {
-	    var view = this.props.initialView,
-	        slideDir = view !== this.state.view || _dates2.default.gt(date, this.state.currentDate) ? 'left' // move down to a the view
-	    : 'right';
-
-	    (0, _widgetHelpers.notify)(this.props.onChange, date);
-
-	    if (this.isValidView(view) && _dates2.default.inRange(date, this.props.min, this.props.max, view)) {
-	      this.focus();
-
-	      this.changeCurrentDate(date);
-
-	      this.setState({
-	        slideDirection: slideDir,
-	        view: view
-	      });
-	    }
-	  },
-	  nextDate: function nextDate(direction) {
-	    var method = direction === dir.LEFT ? 'subtract' : 'add',
-	        view = this.state.view,
-	        unit = view === views.MONTH ? view : views.YEAR,
-	        multi = MULTIPLIER[view] || 1;
-
-	    return _dates2.default[method](this.props.currentDate, 1 * multi, unit);
-	  },
-	  handleKeyDown: function handleKeyDown(e) {
-	    var ctrl = e.ctrlKey,
-	        key = e.key,
-	        direction = ARROWS_TO_DIRECTION[key],
-	        current = this.props.currentDate,
-	        view = this.state.view,
-	        unit = VIEW_UNIT[view],
-	        currentDate = current;
-
-	    if (key === 'Enter') {
-	      e.preventDefault();
-	      return this.change(current);
-	    }
-
-	    if (direction) {
-	      if (ctrl) {
-	        e.preventDefault();
-	        this.navigate(direction);
-	      } else {
-	        if (this.isRtl() && OPPOSITE_DIRECTION[direction]) direction = OPPOSITE_DIRECTION[direction];
-
-	        currentDate = _dates2.default.move(currentDate, this.props.min, this.props.max, view, direction);
-
-	        if (!_dates2.default.eq(current, currentDate, unit)) {
-	          e.preventDefault();
-
-	          if (_dates2.default.gt(currentDate, current, view)) this.navigate(dir.RIGHT, currentDate);else if (_dates2.default.lt(currentDate, current, view)) this.navigate(dir.LEFT, currentDate);else this.changeCurrentDate(currentDate);
-	        }
-	      }
-	    }
-
-	    (0, _widgetHelpers.notify)(this.props.onKeyDown, [e]);
-	  },
-	  _label: function _label() {
-	    var _props2 = this.props,
-	        culture = _props2.culture,
-	        props = _objectWithoutProperties(_props2, ['culture']),
-	        view = this.state.view,
-	        dt = this.props.currentDate;
-
-	    if (view === 'month') return _localizers.date.format(dt, format(props, 'header'), culture);else if (view === 'year') return _localizers.date.format(dt, format(props, 'year'), culture);else if (view === 'decade') return _localizers.date.format(_dates2.default.startOf(dt, 'decade'), format(props, 'decade'), culture);else if (view === 'century') return _localizers.date.format(_dates2.default.startOf(dt, 'century'), format(props, 'century'), culture);
-	  },
-	  inRangeValue: function inRangeValue(_value) {
-	    var value = dateOrNull(_value);
-
-	    if (value === null) return value;
-
-	    return _dates2.default.max(_dates2.default.min(value, this.props.max), this.props.min);
-	  },
-	  isValidView: function isValidView(next) {
-	    var bottom = VIEW_OPTIONS.indexOf(this.props.initialView),
-	        top = VIEW_OPTIONS.indexOf(this.props.finalView),
-	        current = VIEW_OPTIONS.indexOf(next);
-
-	    return current >= bottom && current <= top;
 	  }
-	}, (_applyDecoratedDescriptor(_obj, 'navigate', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'navigate'), _obj), _applyDecoratedDescriptor(_obj, 'change', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'change'), _obj), _applyDecoratedDescriptor(_obj, 'select', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'select'), _obj), _applyDecoratedDescriptor(_obj, 'handleKeyDown', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleKeyDown'), _obj)), _obj));
+	}, (_applyDecoratedDescriptor(_obj, 'navigate', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'navigate'), _obj), _applyDecoratedDescriptor(_obj, 'change', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'change'), _obj)), _obj));
 
 	function dateOrNull(dt) {
 	  if (dt && !isNaN(dt.getTime())) return dt;
@@ -5518,44 +7539,52 @@ return /******/ (function(modules) { // webpackBootstrap
 	}, ['focus']);
 	module.exports = exports['default'];
 
-/***/ },
-/* 67 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 78 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _Button = __webpack_require__(29);
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+	var _Button = __webpack_require__(40);
 
 	var _Button2 = _interopRequireDefault(_Button);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-	exports.default = _react2.default.createClass({
+	exports.default = (0, _createReactClass2.default)({
 	  displayName: 'Header',
 	  propTypes: {
-	    label: _react2.default.PropTypes.string.isRequired,
-	    labelId: _react2.default.PropTypes.string,
+	    label: _propTypes2.default.string.isRequired,
+	    labelId: _propTypes2.default.string,
 
-	    upDisabled: _react2.default.PropTypes.bool.isRequired,
-	    prevDisabled: _react2.default.PropTypes.bool.isRequired,
-	    nextDisabled: _react2.default.PropTypes.bool.isRequired,
-	    onViewChange: _react2.default.PropTypes.func.isRequired,
-	    onMoveLeft: _react2.default.PropTypes.func.isRequired,
-	    onMoveRight: _react2.default.PropTypes.func.isRequired,
+	    upDisabled: _propTypes2.default.bool.isRequired,
+	    prevDisabled: _propTypes2.default.bool.isRequired,
+	    nextDisabled: _propTypes2.default.bool.isRequired,
+	    onViewChange: _propTypes2.default.func.isRequired,
+	    onMoveLeft: _propTypes2.default.func.isRequired,
+	    onMoveRight: _propTypes2.default.func.isRequired,
 
-	    messages: _react2.default.PropTypes.shape({
-	      moveBack: _react2.default.PropTypes.string,
-	      moveForward: _react2.default.PropTypes.string
+	    messages: _propTypes2.default.shape({
+	      moveBack: _propTypes2.default.string,
+	      moveForward: _propTypes2.default.string
 	    })
 	  },
 
-	  mixins: [__webpack_require__(54), __webpack_require__(68)],
+	  mixins: [__webpack_require__(65), __webpack_require__(79)],
 
 	  getDefaultProps: function getDefaultProps() {
 	    return {
@@ -5614,15 +7643,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	module.exports = exports['default'];
 
-/***/ },
-/* 68 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 79 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
@@ -5631,7 +7664,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = {
 
 	  contextTypes: {
-	    isRtl: _react2.default.PropTypes.bool
+	    isRtl: _propTypes2.default.bool
 	  },
 
 	  isRtl: function isRtl() {
@@ -5640,17 +7673,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 	module.exports = exports['default'];
 
-/***/ },
-/* 69 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 80 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	var _react = __webpack_require__(20);
+	var _class, _temp;
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _Button = __webpack_require__(29);
+	var _Button = __webpack_require__(40);
 
 	var _Button2 = _interopRequireDefault(_Button);
 
@@ -5658,15 +7693,26 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
 	var format = function format(props) {
 	  return _localizers.date.getFormat('footer', props.format);
 	};
 
-	module.exports = _react2.default.createClass({
+	module.exports = (_temp = _class = function (_React$Component) {
+	  _inherits(_class, _React$Component);
 
-	  displayName: 'Footer',
+	  function _class() {
+	    _classCallCheck(this, _class);
 
-	  render: function render() {
+	    return _possibleConstructorReturn(this, _React$Component.apply(this, arguments));
+	  }
+
+	  _class.prototype.render = function render() {
 	    var _props = this.props,
 	        disabled = _props.disabled,
 	        readOnly = _props.readOnly,
@@ -5685,40 +7731,50 @@ return /******/ (function(modules) { // webpackBootstrap
 	        _localizers.date.format(value, format(this.props), this.props.culture)
 	      )
 	    );
-	  }
-	});
+	  };
 
-/***/ },
-/* 70 */
-/***/ function(module, exports, __webpack_require__) {
+	  return _class;
+	}(_react2.default.Component), _class.displayName = 'Footer', _temp);
+
+/***/ }),
+/* 81 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _CalendarView = __webpack_require__(71);
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+	var _CalendarView = __webpack_require__(82);
 
 	var _CalendarView2 = _interopRequireDefault(_CalendarView);
 
-	var _dates = __webpack_require__(72);
+	var _dates = __webpack_require__(83);
 
 	var _dates2 = _interopRequireDefault(_dates);
 
 	var _localizers = __webpack_require__(17);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 	var _2 = __webpack_require__(19);
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5734,24 +7790,24 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 	var propTypes = {
-	  culture: _react2.default.PropTypes.string,
-	  today: _react2.default.PropTypes.instanceOf(Date),
-	  value: _react2.default.PropTypes.instanceOf(Date),
-	  focused: _react2.default.PropTypes.instanceOf(Date),
-	  min: _react2.default.PropTypes.instanceOf(Date),
-	  max: _react2.default.PropTypes.instanceOf(Date),
-	  onChange: _react2.default.PropTypes.func.isRequired,
+	  culture: _propTypes2.default.string,
+	  today: _propTypes2.default.instanceOf(Date),
+	  value: _propTypes2.default.instanceOf(Date),
+	  focused: _propTypes2.default.instanceOf(Date),
+	  min: _propTypes2.default.instanceOf(Date),
+	  max: _propTypes2.default.instanceOf(Date),
+	  onChange: _propTypes2.default.func.isRequired,
 
-	  dayComponent: _propTypes2.default.elementType,
-	  dayFormat: _propTypes2.default.dateFormat,
-	  dateFormat: _propTypes2.default.dateFormat
+	  dayComponent: _propTypes4.default.elementType,
+	  dayFormat: _propTypes4.default.dateFormat,
+	  dateFormat: _propTypes4.default.dateFormat
 	};
 
 	var isEqual = function isEqual(dateA, dateB) {
 	  return _dates2.default.eq(dateA, dateB, 'day');
 	};
 
-	var MonthView = _react2.default.createClass({
+	var MonthView = (0, _createReactClass2.default)({
 
 	  displayName: 'MonthView',
 
@@ -5759,7 +7815,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    isEqual: isEqual
 	  },
 
-	  mixins: [__webpack_require__(68), __webpack_require__(45)()],
+	  mixins: [__webpack_require__(79), __webpack_require__(56)()],
 
 	  propTypes: propTypes,
 
@@ -5852,9 +7908,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = MonthView;
 	module.exports = exports['default'];
 
-/***/ },
-/* 71 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 82 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -5864,15 +7920,19 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _classnames = __webpack_require__(25);
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
-	var _dates = __webpack_require__(72);
+	var _dates = __webpack_require__(83);
 
 	var _dates2 = _interopRequireDefault(_dates);
 
@@ -6011,16 +8071,16 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  return CalendarViewCell;
 	}(_react2.default.Component), _class.propTypes = {
-	  id: _react2.default.PropTypes.string,
-	  label: _react2.default.PropTypes.string,
-	  today: _react2.default.PropTypes.instanceOf(Date),
-	  selected: _react2.default.PropTypes.instanceOf(Date),
-	  focused: _react2.default.PropTypes.instanceOf(Date),
-	  min: _react2.default.PropTypes.instanceOf(Date),
-	  max: _react2.default.PropTypes.instanceOf(Date),
-	  unit: _react2.default.PropTypes.oneOf(['day'].concat(VIEW_UNITS)),
-	  viewUnit: _react2.default.PropTypes.oneOf(VIEW_UNITS),
-	  onChange: _react2.default.PropTypes.func.isRequired
+	  id: _propTypes2.default.string,
+	  label: _propTypes2.default.string,
+	  today: _propTypes2.default.instanceOf(Date),
+	  selected: _propTypes2.default.instanceOf(Date),
+	  focused: _propTypes2.default.instanceOf(Date),
+	  min: _propTypes2.default.instanceOf(Date),
+	  max: _propTypes2.default.instanceOf(Date),
+	  unit: _propTypes2.default.oneOf(['day'].concat(VIEW_UNITS)),
+	  viewUnit: _propTypes2.default.oneOf(VIEW_UNITS),
+	  onChange: _propTypes2.default.func.isRequired
 	}, _temp2);
 
 
@@ -6032,9 +8092,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = CalendarView;
 	module.exports = exports['default'];
 
-/***/ },
-/* 72 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 83 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -6042,11 +8102,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _dateArithmetic = __webpack_require__(73);
+	var _dateArithmetic = __webpack_require__(84);
 
 	var _dateArithmetic2 = _interopRequireDefault(_dateArithmetic);
 
-	var _constants = __webpack_require__(74);
+	var _constants = __webpack_require__(85);
 
 	var _localizers = __webpack_require__(17);
 
@@ -6131,9 +8191,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = dates;
 	module.exports = exports['default'];
 
-/***/ },
-/* 73 */
-/***/ function(module, exports) {
+/***/ }),
+/* 84 */
+/***/ (function(module, exports) {
 
 	var MILI    = 'milliseconds'
 	  , SECONDS = 'seconds'
@@ -6358,9 +8418,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 
-/***/ },
-/* 74 */
-/***/ function(module, exports) {
+/***/ }),
+/* 85 */
+/***/ (function(module, exports) {
 
 	'use strict';
 
@@ -6393,23 +8453,31 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var calendarViewUnits = exports.calendarViewUnits = (_calendarViewUnits = {}, _calendarViewUnits[views.MONTH] = 'day', _calendarViewUnits[views.YEAR] = views.MONTH, _calendarViewUnits[views.DECADE] = views.YEAR, _calendarViewUnits[views.CENTURY] = views.DECADE, _calendarViewUnits);
 
-/***/ },
-/* 75 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 86 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _CalendarView = __webpack_require__(71);
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+	var _CalendarView = __webpack_require__(82);
 
 	var _CalendarView2 = _interopRequireDefault(_CalendarView);
 
-	var _dates = __webpack_require__(72);
+	var _dates = __webpack_require__(83);
 
 	var _dates2 = _interopRequireDefault(_dates);
 
@@ -6419,11 +8487,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -6432,26 +8500,26 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 	var propTypes = {
-	  culture: _react2.default.PropTypes.string,
-	  today: _react2.default.PropTypes.instanceOf(Date),
-	  value: _react2.default.PropTypes.instanceOf(Date),
-	  focused: _react2.default.PropTypes.instanceOf(Date),
-	  min: _react2.default.PropTypes.instanceOf(Date),
-	  max: _react2.default.PropTypes.instanceOf(Date),
-	  onChange: _react2.default.PropTypes.func.isRequired,
+	  culture: _propTypes2.default.string,
+	  today: _propTypes2.default.instanceOf(Date),
+	  value: _propTypes2.default.instanceOf(Date),
+	  focused: _propTypes2.default.instanceOf(Date),
+	  min: _propTypes2.default.instanceOf(Date),
+	  max: _propTypes2.default.instanceOf(Date),
+	  onChange: _propTypes2.default.func.isRequired,
 
-	  monthFormat: _propTypes2.default.dateFormat
+	  monthFormat: _propTypes4.default.dateFormat
 	};
 
 	var optionId = function optionId(id, date) {
 	  return id + '__year_' + _dates2.default.year(date) + '-' + _dates2.default.month(date);
 	};
 
-	var YearView = _react2.default.createClass({
+	var YearView = (0, _createReactClass2.default)({
 
 	  displayName: 'YearView',
 
-	  mixins: [__webpack_require__(68), __webpack_require__(45)()],
+	  mixins: [__webpack_require__(79), __webpack_require__(56)()],
 
 	  propTypes: propTypes,
 
@@ -6523,23 +8591,31 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = YearView;
 	module.exports = exports['default'];
 
-/***/ },
-/* 76 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 87 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _CalendarView = __webpack_require__(71);
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+	var _CalendarView = __webpack_require__(82);
 
 	var _CalendarView2 = _interopRequireDefault(_CalendarView);
 
-	var _dates = __webpack_require__(72);
+	var _dates = __webpack_require__(83);
 
 	var _dates2 = _interopRequireDefault(_dates);
 
@@ -6549,35 +8625,35 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 	var propTypes = {
-	  culture: _react2.default.PropTypes.string,
-	  today: _react2.default.PropTypes.instanceOf(Date),
-	  value: _react2.default.PropTypes.instanceOf(Date),
-	  focused: _react2.default.PropTypes.instanceOf(Date),
-	  min: _react2.default.PropTypes.instanceOf(Date),
-	  max: _react2.default.PropTypes.instanceOf(Date),
-	  onChange: _react2.default.PropTypes.func.isRequired,
+	  culture: _propTypes2.default.string,
+	  today: _propTypes2.default.instanceOf(Date),
+	  value: _propTypes2.default.instanceOf(Date),
+	  focused: _propTypes2.default.instanceOf(Date),
+	  min: _propTypes2.default.instanceOf(Date),
+	  max: _propTypes2.default.instanceOf(Date),
+	  onChange: _propTypes2.default.func.isRequired,
 
-	  yearFormat: _propTypes2.default.dateFormat
+	  yearFormat: _propTypes4.default.dateFormat
 	};
 
 	var optionId = function optionId(id, date) {
 	  return id + '__decade_' + _dates2.default.year(date);
 	};
 
-	exports.default = _react2.default.createClass({
+	exports.default = (0, _createReactClass2.default)({
 
 	  displayName: 'DecadeView',
 
-	  mixins: [__webpack_require__(54), __webpack_require__(68), __webpack_require__(45)()],
+	  mixins: [__webpack_require__(65), __webpack_require__(79), __webpack_require__(56)()],
 
 	  propTypes: propTypes,
 
@@ -6654,23 +8730,31 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	module.exports = exports['default'];
 
-/***/ },
-/* 77 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 88 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _CalendarView = __webpack_require__(71);
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+	var _CalendarView = __webpack_require__(82);
 
 	var _CalendarView2 = _interopRequireDefault(_CalendarView);
 
-	var _dates = __webpack_require__(72);
+	var _dates = __webpack_require__(83);
 
 	var _dates2 = _interopRequireDefault(_dates);
 
@@ -6680,11 +8764,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -6697,21 +8781,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 	var propTypes = {
-	  culture: _react2.default.PropTypes.string,
-	  today: _react2.default.PropTypes.instanceOf(Date),
-	  value: _react2.default.PropTypes.instanceOf(Date),
-	  focused: _react2.default.PropTypes.instanceOf(Date),
-	  min: _react2.default.PropTypes.instanceOf(Date),
-	  max: _react2.default.PropTypes.instanceOf(Date),
-	  onChange: _react2.default.PropTypes.func.isRequired,
-	  decadeFormat: _propTypes2.default.dateFormat
+	  culture: _propTypes2.default.string,
+	  today: _propTypes2.default.instanceOf(Date),
+	  value: _propTypes2.default.instanceOf(Date),
+	  focused: _propTypes2.default.instanceOf(Date),
+	  min: _propTypes2.default.instanceOf(Date),
+	  max: _propTypes2.default.instanceOf(Date),
+	  onChange: _propTypes2.default.func.isRequired,
+	  decadeFormat: _propTypes4.default.dateFormat
 	};
 
-	exports.default = _react2.default.createClass({
+	exports.default = (0, _createReactClass2.default)({
 
 	  displayName: 'CenturyView',
 
-	  mixins: [__webpack_require__(54), __webpack_require__(68), __webpack_require__(45)()],
+	  mixins: [__webpack_require__(65), __webpack_require__(79), __webpack_require__(56)()],
 
 	  propTypes: propTypes,
 
@@ -6789,23 +8873,29 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	module.exports = exports['default'];
 
-/***/ },
-/* 78 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 89 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
+	var _class, _temp2, _class2, _temp4;
+
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _ReplaceTransitionGroup = __webpack_require__(79);
+	var _ReplaceTransitionGroup = __webpack_require__(90);
 
 	var _ReplaceTransitionGroup2 = _interopRequireDefault(_ReplaceTransitionGroup);
 
-	var _compat = __webpack_require__(38);
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
@@ -6813,7 +8903,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _style2 = _interopRequireDefault(_style);
 
-	var _width = __webpack_require__(80);
+	var _width = __webpack_require__(91);
 
 	var _width2 = _interopRequireDefault(_width);
 
@@ -6827,92 +8917,103 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-	var SlideChildGroup = _react2.default.createClass({
-	  displayName: 'SlideChildGroup',
+	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-	  propTypes: {
-	    direction: _react2.default.PropTypes.oneOf(['left', 'right']),
-	    duration: _react2.default.PropTypes.number
-	  },
+	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-	  componentWillEnter: function componentWillEnter(done) {
-	    var _this = this;
+	var SlideChildGroup = (_temp2 = _class = function (_React$Component) {
+	  _inherits(SlideChildGroup, _React$Component);
 
-	    var node = _compat2.default.findDOMNode(this),
-	        width = (0, _width2.default)(node),
-	        direction = this.props.direction;
+	  function SlideChildGroup() {
+	    var _temp, _this, _ret;
 
-	    width = direction === 'left' ? width : -width;
+	    _classCallCheck(this, SlideChildGroup);
 
-	    this.ORGINAL_POSITION = node.style.position;
+	    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+	      args[_key] = arguments[_key];
+	    }
 
-	    (0, _style2.default)(node, { position: 'absolute', left: width + 'px', top: 0 });
+	    return _ret = (_temp = (_this = _possibleConstructorReturn(this, _React$Component.call.apply(_React$Component, [this].concat(args))), _this), _this.componentWillEnter = function (done) {
+	      var node = _compat2.default.findDOMNode(_this),
+	          width = (0, _width2.default)(node),
+	          direction = _this.props.direction;
 
-	    _configuration2.default.animate(node, { left: 0 }, this.props.duration, function () {
+	      width = direction === 'left' ? width : -width;
 
-	      (0, _style2.default)(node, {
-	        position: _this.ORGINAL_POSITION,
-	        overflow: 'hidden'
+	      _this.ORGINAL_POSITION = node.style.position;
+
+	      (0, _style2.default)(node, { position: 'absolute', left: width + 'px', top: 0 });
+
+	      _configuration2.default.animate(node, { left: 0 }, _this.props.duration, function () {
+
+	        (0, _style2.default)(node, {
+	          position: _this.ORGINAL_POSITION,
+	          overflow: 'hidden'
+	        });
+
+	        _this.ORGINAL_POSITION = null;
+	        done && done();
 	      });
+	    }, _this.componentWillLeave = function (done) {
+	      var node = _compat2.default.findDOMNode(_this),
+	          width = (0, _width2.default)(node),
+	          direction = _this.props.direction;
 
-	      _this.ORGINAL_POSITION = null;
-	      done && done();
-	    });
-	  },
-	  componentWillLeave: function componentWillLeave(done) {
-	    var _this2 = this;
+	      width = direction === 'left' ? -width : width;
 
-	    var node = _compat2.default.findDOMNode(this),
-	        width = (0, _width2.default)(node),
-	        direction = this.props.direction;
+	      _this.ORGINAL_POSITION = node.style.position;
 
-	    width = direction === 'left' ? -width : width;
+	      (0, _style2.default)(node, { position: 'absolute', top: 0, left: 0 });
 
-	    this.ORGINAL_POSITION = node.style.position;
+	      _configuration2.default.animate(node, { left: width + 'px' }, _this.props.duration, function () {
+	        (0, _style2.default)(node, {
+	          position: _this.ORGINAL_POSITION,
+	          overflow: 'hidden'
+	        });
 
-	    (0, _style2.default)(node, { position: 'absolute', top: 0, left: 0 });
-
-	    _configuration2.default.animate(node, { left: width + 'px' }, this.props.duration, function () {
-	      (0, _style2.default)(node, {
-	        position: _this2.ORGINAL_POSITION,
-	        overflow: 'hidden'
+	        _this.ORGINAL_POSITION = null;
+	        done && done();
 	      });
-
-	      _this2.ORGINAL_POSITION = null;
-	      done && done();
-	    });
-	  },
-	  render: function render() {
-	    return _react2.default.Children.only(this.props.children);
+	    }, _temp), _possibleConstructorReturn(_this, _ret);
 	  }
-	});
 
-	module.exports = _react2.default.createClass({
-	  displayName: 'exports',
+	  SlideChildGroup.prototype.render = function render() {
+	    return _react2.default.Children.only(this.props.children);
+	  };
+
+	  return SlideChildGroup;
+	}(_react2.default.Component), _class.propTypes = {
+	  direction: _propTypes2.default.oneOf(['left', 'right']),
+	  duration: _propTypes2.default.number
+	}, _temp2);
 
 
-	  propTypes: {
-	    direction: _react2.default.PropTypes.oneOf(['left', 'right']),
-	    duration: _react2.default.PropTypes.number
-	  },
+	module.exports = (_temp4 = _class2 = function (_React$Component2) {
+	  _inherits(_class2, _React$Component2);
 
-	  getDefaultProps: function getDefaultProps() {
-	    return {
-	      direction: 'left',
-	      duration: 250
-	    };
-	  },
-	  _wrapChild: function _wrapChild(child, ref) {
-	    return _react2.default.createElement(
-	      SlideChildGroup,
-	      { key: child.key, ref: ref,
-	        direction: this.props.direction,
-	        duration: this.props.duration },
-	      child
-	    );
-	  },
-	  render: function render() {
+	  function _class2() {
+	    var _temp3, _this2, _ret2;
+
+	    _classCallCheck(this, _class2);
+
+	    for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+	      args[_key2] = arguments[_key2];
+	    }
+
+	    return _ret2 = (_temp3 = (_this2 = _possibleConstructorReturn(this, _React$Component2.call.apply(_React$Component2, [this].concat(args))), _this2), _this2._wrapChild = function (child, ref) {
+	      return _react2.default.createElement(
+	        SlideChildGroup,
+	        { key: child.key, ref: ref,
+	          direction: _this2.props.direction,
+	          duration: _this2.props.duration },
+	        child
+	      );
+	    }, _temp3), _possibleConstructorReturn(_this2, _ret2);
+	  }
+
+	  _class2.prototype.render = function render() {
 	    var _props = this.props,
 	        style = _props.style,
 	        children = _props.children;
@@ -6933,34 +9034,50 @@ return /******/ (function(modules) { // webpackBootstrap
 	      }),
 	      children
 	    );
-	  }
-	});
+	  };
 
-/***/ },
-/* 79 */
-/***/ function(module, exports, __webpack_require__) {
+	  return _class2;
+	}(_react2.default.Component), _class2.propTypes = {
+	  direction: _propTypes2.default.oneOf(['left', 'right']),
+	  duration: _propTypes2.default.number
+	}, _class2.defaultProps = {
+	  direction: 'left',
+	  duration: 250
+	}, _temp4);
+
+/***/ }),
+/* 90 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
+
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 	var _style = __webpack_require__(6);
 
 	var _style2 = _interopRequireDefault(_style);
 
-	var _height = __webpack_require__(35);
+	var _height = __webpack_require__(46);
 
 	var _height2 = _interopRequireDefault(_height);
 
-	var _width = __webpack_require__(80);
+	var _width = __webpack_require__(91);
 
 	var _width2 = _interopRequireDefault(_width);
 
-	var _compat = __webpack_require__(38);
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
@@ -6984,15 +9101,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return child && child.key;
 	}
 
-	exports.default = _react2.default.createClass({
+	exports.default = (0, _createReactClass2.default)({
 
 	  displayName: 'ReplaceTransitionGroup',
 
 	  propTypes: {
-	    component: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.element, _react2.default.PropTypes.string]),
-	    childFactory: _react2.default.PropTypes.func,
-	    onAnimating: _react2.default.PropTypes.func,
-	    onAnimate: _react2.default.PropTypes.func
+	    component: _propTypes2.default.oneOfType([_propTypes2.default.element, _propTypes2.default.string]),
+	    childFactory: _propTypes2.default.func,
+	    onAnimating: _propTypes2.default.func,
+	    onAnimate: _propTypes2.default.func
 	  },
 
 	  getDefaultProps: function getDefaultProps() {
@@ -7140,23 +9257,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	module.exports = exports['default'];
 
-/***/ },
-/* 80 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 91 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	var offset = __webpack_require__(36),
-	    getWindow = __webpack_require__(37);
+	var offset = __webpack_require__(47),
+	    getWindow = __webpack_require__(48);
 
 	module.exports = function width(node, client) {
 	  var win = getWindow(node);
 	  return win ? win.innerWidth : client ? node.clientWidth : offset(node).width;
 	};
 
-/***/ },
-/* 81 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 92 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -7166,23 +9283,27 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; //pick, omit, has
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
 
-	var _react2 = _interopRequireDefault(_react);
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 	var _invariant = __webpack_require__(18);
 
 	var _invariant2 = _interopRequireDefault(_invariant);
 
-	var _activeElement = __webpack_require__(22);
+	var _activeElement = __webpack_require__(33);
 
 	var _activeElement2 = _interopRequireDefault(_activeElement);
 
-	var _classnames = __webpack_require__(25);
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
-	var _compat = __webpack_require__(38);
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
@@ -7190,49 +9311,49 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _dates = __webpack_require__(72);
+	var _dates = __webpack_require__(83);
 
 	var _dates2 = _interopRequireDefault(_dates);
 
 	var _localizers = __webpack_require__(17);
 
-	var _constants = __webpack_require__(74);
+	var _constants = __webpack_require__(85);
 
-	var _Widget = __webpack_require__(26);
+	var _Widget = __webpack_require__(37);
 
 	var _Widget2 = _interopRequireDefault(_Widget);
 
-	var _Popup = __webpack_require__(34);
+	var _Popup = __webpack_require__(45);
 
 	var _Popup2 = _interopRequireDefault(_Popup);
 
-	var _Calendar = __webpack_require__(66);
+	var _Calendar = __webpack_require__(77);
 
 	var _Calendar2 = _interopRequireDefault(_Calendar);
 
-	var _TimeList = __webpack_require__(82);
+	var _TimeList = __webpack_require__(93);
 
 	var _TimeList2 = _interopRequireDefault(_TimeList);
 
-	var _DateTimePickerInput = __webpack_require__(83);
+	var _DateTimePickerInput = __webpack_require__(94);
 
 	var _DateTimePickerInput2 = _interopRequireDefault(_DateTimePickerInput);
 
-	var _Button = __webpack_require__(29);
+	var _Button = __webpack_require__(40);
 
 	var _Button2 = _interopRequireDefault(_Button);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
-	var _uncontrollable = __webpack_require__(49);
+	var _uncontrollable = __webpack_require__(60);
 
 	var _uncontrollable2 = _interopRequireDefault(_uncontrollable);
 
-	var _interaction = __webpack_require__(43);
+	var _interaction = __webpack_require__(54);
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7274,63 +9395,63 @@ return /******/ (function(modules) { // webpackBootstrap
 	var propTypes = _extends({}, Calendar.propTypes, {
 
 	  //-- controlled props -----------
-	  value: _react2.default.PropTypes.instanceOf(Date),
-	  onChange: _react2.default.PropTypes.func,
-	  open: _react2.default.PropTypes.oneOf([false, _constants.datePopups.TIME, _constants.datePopups.CALENDAR]),
-	  onToggle: _react2.default.PropTypes.func,
-	  currentDate: _react2.default.PropTypes.instanceOf(Date),
-	  onCurrentDateChange: _react2.default.PropTypes.func,
+	  value: _propTypes2.default.instanceOf(Date),
+	  onChange: _propTypes2.default.func,
+	  open: _propTypes2.default.oneOf([false, _constants.datePopups.TIME, _constants.datePopups.CALENDAR]),
+	  onToggle: _propTypes2.default.func,
+	  currentDate: _propTypes2.default.instanceOf(Date),
+	  onCurrentDateChange: _propTypes2.default.func,
 	  //------------------------------------
 
-	  onSelect: _react2.default.PropTypes.func,
+	  onSelect: _propTypes2.default.func,
 
-	  min: _react2.default.PropTypes.instanceOf(Date),
-	  max: _react2.default.PropTypes.instanceOf(Date),
+	  min: _propTypes2.default.instanceOf(Date),
+	  max: _propTypes2.default.instanceOf(Date),
 
-	  culture: _react2.default.PropTypes.string,
+	  culture: _propTypes2.default.string,
 
-	  format: _propTypes2.default.dateFormat,
-	  timeFormat: _propTypes2.default.dateFormat,
-	  editFormat: _propTypes2.default.dateFormat,
+	  format: _propTypes4.default.dateFormat,
+	  timeFormat: _propTypes4.default.dateFormat,
+	  editFormat: _propTypes4.default.dateFormat,
 
-	  calendar: _react2.default.PropTypes.bool,
-	  time: _react2.default.PropTypes.bool,
+	  calendar: _propTypes2.default.bool,
+	  time: _propTypes2.default.bool,
 
-	  timeComponent: _propTypes2.default.elementType,
+	  timeComponent: _propTypes4.default.elementType,
 
 	  //popup
-	  dropUp: _react2.default.PropTypes.bool,
-	  duration: _react2.default.PropTypes.number,
+	  dropUp: _propTypes2.default.bool,
+	  duration: _propTypes2.default.number,
 
-	  placeholder: _react2.default.PropTypes.string,
-	  name: _react2.default.PropTypes.string,
+	  placeholder: _propTypes2.default.string,
+	  name: _propTypes2.default.string,
 
-	  initialView: _react2.default.PropTypes.oneOf(viewEnum),
-	  finalView: _react2.default.PropTypes.oneOf(viewEnum),
+	  initialView: _propTypes2.default.oneOf(viewEnum),
+	  finalView: _propTypes2.default.oneOf(viewEnum),
 
-	  autoFocus: _react2.default.PropTypes.bool,
-	  disabled: _propTypes2.default.disabled,
-	  readOnly: _propTypes2.default.readOnly,
+	  autoFocus: _propTypes2.default.bool,
+	  disabled: _propTypes4.default.disabled,
+	  readOnly: _propTypes4.default.readOnly,
 
-	  parse: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.arrayOf(_react2.default.PropTypes.string), _react2.default.PropTypes.string, _react2.default.PropTypes.func]),
+	  parse: _propTypes2.default.oneOfType([_propTypes2.default.arrayOf(_propTypes2.default.string), _propTypes2.default.string, _propTypes2.default.func]),
 
-	  'aria-labelledby': _react2.default.PropTypes.string,
+	  'aria-labelledby': _propTypes2.default.string,
 
-	  messages: _react2.default.PropTypes.shape({
-	    calendarButton: _react2.default.PropTypes.string,
-	    timeButton: _react2.default.PropTypes.string
+	  messages: _propTypes2.default.shape({
+	    calendarButton: _propTypes2.default.string,
+	    timeButton: _propTypes2.default.string
 	  })
 	});
 
-	var DateTimePicker = _react2.default.createClass((_obj = {
+	var DateTimePicker = (0, _createReactClass2.default)((_obj = {
 
 	  displayName: 'DateTimePicker',
 
-	  mixins: [__webpack_require__(52), __webpack_require__(54), __webpack_require__(56), __webpack_require__(61), __webpack_require__(62)({
+	  mixins: [__webpack_require__(63), __webpack_require__(65), __webpack_require__(67), __webpack_require__(72), __webpack_require__(73)({
 	    didHandle: function didHandle(focused) {
 	      if (!focused) this.close();
 	    }
-	  }), __webpack_require__(45)('valueInput', function (key, id) {
+	  }), __webpack_require__(56)('valueInput', function (key, id) {
 	    var open = this.props.open,
 	        current = this.ariaActiveDescendant(),
 	        calIsActive = open === _constants.datePopups.CALENDAR && key === 'calendar',
@@ -7387,7 +9508,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var focused = this.state.focused;
 
 
-	    return _react2.default.createElement(_DateTimePickerInput2.default, {
+	    return React.createElement(_DateTimePickerInput2.default, {
 	      id: id,
 	      ref: 'valueInput',
 	      role: 'combobox',
@@ -7424,17 +9545,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return null;
 	    }
 
-	    return _react2.default.createElement(
+	    return React.createElement(
 	      'span',
 	      { className: 'rw-select' },
-	      calendar && _react2.default.createElement(_Button2.default, {
+	      calendar && React.createElement(_Button2.default, {
 	        icon: 'calendar',
 	        className: 'rw-btn-calendar',
 	        label: messages.calendarButton,
 	        disabled: !!(disabled || readOnly),
 	        onClick: this._click.bind(null, _constants.datePopups.CALENDAR)
 	      }),
-	      time && _react2.default.createElement(_Button2.default, {
+	      time && React.createElement(_Button2.default, {
 	        icon: 'clock-o',
 	        className: 'rw-btn-time',
 	        label: messages.timeButton,
@@ -7455,7 +9576,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    var calendarProps = _3.default.pickProps(this.props, Calendar);
 
-	    return _react2.default.createElement(
+	    return React.createElement(
 	      _Popup2.default,
 	      {
 	        dropUp: dropUp,
@@ -7463,7 +9584,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        open: open === _constants.datePopups.CALENDAR,
 	        className: 'rw-calendar-popup'
 	      },
-	      _react2.default.createElement(Calendar, _extends({}, calendarProps, {
+	      React.createElement(Calendar, _extends({}, calendarProps, {
 	        ref: 'calPopup',
 	        id: id,
 	        tabIndex: '-1',
@@ -7499,7 +9620,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    var timeListProps = _3.default.pickProps(this.props, _TimeList2.default);
 
-	    return _react2.default.createElement(
+	    return React.createElement(
 	      _Popup2.default,
 	      {
 	        dropUp: dropUp,
@@ -7509,10 +9630,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	          return _this2.refs.timePopup.forceUpdate();
 	        }
 	      },
-	      _react2.default.createElement(
+	      React.createElement(
 	        'div',
 	        null,
-	        _react2.default.createElement(_TimeList2.default, _extends({}, timeListProps, {
+	        React.createElement(_TimeList2.default, _extends({}, timeListProps, {
 	          ref: 'timePopup',
 	          id: id,
 	          format: timeFormat,
@@ -7554,7 +9675,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (calendar) owns += dateListID;
 	    if (time) owns += ' ' + timeListID;
 
-	    return _react2.default.createElement(
+	    return React.createElement(
 	      _Widget2.default,
 	      _extends({}, elementProps, {
 	        open: !!open,
@@ -7722,9 +9843,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	module.exports = exports['default'];
 
-/***/ },
-/* 82 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 93 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -7732,23 +9853,31 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _dates2 = __webpack_require__(72);
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+	var _dates2 = __webpack_require__(83);
 
 	var _dates3 = _interopRequireDefault(_dates2);
 
-	var _List = __webpack_require__(40);
+	var _List = __webpack_require__(51);
 
 	var _List2 = _interopRequireDefault(_List);
 
 	var _localizers = __webpack_require__(17);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 	var _2 = __webpack_require__(19);
 
@@ -7760,27 +9889,27 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return _localizers.date.getFormat('time', props.format);
 	};
 
-	exports.default = _react2.default.createClass({
+	exports.default = (0, _createReactClass2.default)({
 
 	  displayName: 'TimeList',
 
 	  propTypes: {
-	    value: _react2.default.PropTypes.instanceOf(Date),
-	    step: _react2.default.PropTypes.number,
-	    min: _react2.default.PropTypes.instanceOf(Date),
-	    max: _react2.default.PropTypes.instanceOf(Date),
-	    currentDate: _react2.default.PropTypes.instanceOf(Date),
-	    offsetMinutes: _react2.default.PropTypes.number,
+	    value: _propTypes2.default.instanceOf(Date),
+	    step: _propTypes2.default.number,
+	    min: _propTypes2.default.instanceOf(Date),
+	    max: _propTypes2.default.instanceOf(Date),
+	    currentDate: _propTypes2.default.instanceOf(Date),
+	    offsetMinutes: _propTypes2.default.number,
 
-	    itemComponent: _propTypes2.default.elementType,
-	    format: _propTypes2.default.dateFormat,
-	    onSelect: _react2.default.PropTypes.func,
-	    preserveDate: _react2.default.PropTypes.bool,
-	    culture: _react2.default.PropTypes.string,
-	    delay: _react2.default.PropTypes.number
+	    itemComponent: _propTypes4.default.elementType,
+	    format: _propTypes4.default.dateFormat,
+	    onSelect: _propTypes2.default.func,
+	    preserveDate: _propTypes2.default.bool,
+	    culture: _propTypes2.default.string,
+	    delay: _propTypes2.default.number
 	  },
 
-	  mixins: [__webpack_require__(52)],
+	  mixins: [__webpack_require__(63)],
 
 	  getDefaultProps: function getDefaultProps() {
 	    return {
@@ -7953,17 +10082,24 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	module.exports = exports['default'];
 
-/***/ },
-/* 83 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 94 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
+	exports.default = undefined;
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
+	var _class, _temp, _initialiseProps;
+
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
@@ -7971,38 +10107,52 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _Input = __webpack_require__(27);
+	var _Input = __webpack_require__(38);
 
 	var _Input2 = _interopRequireDefault(_Input);
 
-	var _compat = __webpack_require__(38);
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
 	var _localizers = __webpack_require__(17);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-	exports.default = _react2.default.createClass({
+	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-	  displayName: 'DateTimePickerInput',
+	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-	  propTypes: {
-	    format: _propTypes2.default.dateFormat.isRequired,
-	    editing: _react2.default.PropTypes.bool,
-	    editFormat: _propTypes2.default.dateFormat,
-	    parse: _react2.default.PropTypes.func.isRequired,
+	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-	    value: _react2.default.PropTypes.instanceOf(Date),
-	    onChange: _react2.default.PropTypes.func.isRequired,
-	    culture: _react2.default.PropTypes.string
-	  },
+	var _default = (_temp = _class = function (_React$Component) {
+	  _inherits(_default, _React$Component);
 
-	  componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
+	  function _default(props) {
+	    _classCallCheck(this, _default);
+
+	    var _this = _possibleConstructorReturn(this, _React$Component.call(this, props));
+
+	    _initialiseProps.call(_this);
+
+	    var value = props.value,
+	        editing = props.editing,
+	        editFormat = props.editFormat,
+	        format = props.format,
+	        culture = props.culture;
+
+
+	    _this.state = {
+	      textValue: formatDate(value, editing && editFormat ? editFormat : format, culture)
+	    };
+	    return _this;
+	  }
+
+	  _default.prototype.componentWillReceiveProps = function componentWillReceiveProps(nextProps) {
 	    var value = nextProps.value,
 	        editing = nextProps.editing,
 	        editFormat = nextProps.editFormat,
@@ -8013,24 +10163,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	    this.setState({
 	      textValue: formatDate(value, editing && editFormat ? editFormat : format, culture)
 	    });
-	  },
-	  getInitialState: function getInitialState() {
+	  };
+
+	  _default.prototype.render = function render() {
 	    var _props = this.props,
-	        value = _props.value,
-	        editing = _props.editing,
-	        editFormat = _props.editFormat,
-	        format = _props.format,
-	        culture = _props.culture;
-
-
-	    return {
-	      textValue: formatDate(value, editing && editFormat ? editFormat : format, culture)
-	    };
-	  },
-	  render: function render() {
-	    var _props2 = this.props,
-	        disabled = _props2.disabled,
-	        readOnly = _props2.readOnly;
+	        disabled = _props.disabled,
+	        readOnly = _props.readOnly;
 	    var textValue = this.state.textValue;
 
 
@@ -8046,44 +10184,63 @@ return /******/ (function(modules) { // webpackBootstrap
 	      onKeyDown: this.handleKeyDown,
 	      size: textValue.length
 	    }));
-	  },
-	  handleKeyDown: function handleKeyDown(event) {
+	  };
+
+	  return _default;
+	}(_react2.default.Component), _class.displayName = 'DateTimePickerInput', _class.propTypes = {
+	  format: _propTypes4.default.dateFormat.isRequired,
+	  editing: _propTypes2.default.bool,
+	  editFormat: _propTypes4.default.dateFormat,
+	  parse: _propTypes2.default.func.isRequired,
+
+	  value: _propTypes2.default.instanceOf(Date),
+	  onChange: _propTypes2.default.func.isRequired,
+	  culture: _propTypes2.default.string
+	}, _initialiseProps = function _initialiseProps() {
+	  var _this2 = this;
+
+	  this.handleKeyDown = function (event) {
 	    if (event.key == 'Enter') {
-	      var date = this.props.parse(event.target.value);
-	      _compat2.default.findDOMNode(this).blur();
-	      this.props.onChange(date, formatDate(date, this.props.format, this.props.culture));
+	      var date = _this2.props.parse(event.target.value);
+	      _compat2.default.findDOMNode(_this2).blur();
+	      _this2.props.onChange(date, formatDate(date, _this2.props.format, _this2.props.culture));
 	    } else if (event.key == 'Escape') {
-	      _compat2.default.findDOMNode(this).blur();
+	      _compat2.default.findDOMNode(_this2).blur();
 	    }
-	  },
-	  handleChange: function handleChange(_ref) {
+	  };
+
+	  this.handleChange = function (_ref) {
 	    var value = _ref.target.value;
 
-	    this._needsFlush = true;
-	    this.setState({ textValue: value });
-	  },
-	  handleBlur: function handleBlur(event) {
-	    var _props3 = this.props,
-	        format = _props3.format,
-	        culture = _props3.culture,
-	        parse = _props3.parse,
-	        onChange = _props3.onChange,
-	        onBlur = _props3.onBlur;
+	    _this2._needsFlush = true;
+	    _this2.setState({ textValue: value });
+	  };
+
+	  this.handleBlur = function (event) {
+	    var _props2 = _this2.props,
+	        format = _props2.format,
+	        culture = _props2.culture,
+	        parse = _props2.parse,
+	        onChange = _props2.onChange,
+	        onBlur = _props2.onBlur;
 
 
 	    onBlur && onBlur(event);
 
-	    if (this._needsFlush) {
+	    if (_this2._needsFlush) {
 	      var date = parse(event.target.value);
 
-	      this._needsFlush = false;
+	      _this2._needsFlush = false;
 	      onChange(date, formatDate(date, format, culture));
 	    }
-	  },
-	  focus: function focus() {
-	    _compat2.default.findDOMNode(this).focus();
-	  }
-	});
+	  };
+
+	  this.focus = function () {
+	    _compat2.default.findDOMNode(_this2).focus();
+	  };
+	}, _temp);
+
+	exports.default = _default;
 
 
 	function isValid(d) {
@@ -8099,9 +10256,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	module.exports = exports['default'];
 
-/***/ },
-/* 84 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 95 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -8111,11 +10268,19 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _desc, _value, _obj;
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _classnames = __webpack_require__(25);
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
@@ -8123,37 +10288,37 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _compat = __webpack_require__(38);
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
-	var _uncontrollable = __webpack_require__(49);
+	var _uncontrollable = __webpack_require__(60);
 
 	var _uncontrollable2 = _interopRequireDefault(_uncontrollable);
 
-	var _constants = __webpack_require__(74);
+	var _constants = __webpack_require__(85);
 
-	var _repeater = __webpack_require__(85);
+	var _repeater = __webpack_require__(96);
 
 	var _repeater2 = _interopRequireDefault(_repeater);
 
 	var _localizers = __webpack_require__(17);
 
-	var _NumberInput = __webpack_require__(86);
+	var _NumberInput = __webpack_require__(97);
 
 	var _NumberInput2 = _interopRequireDefault(_NumberInput);
 
-	var _Button = __webpack_require__(29);
+	var _Button = __webpack_require__(40);
 
 	var _Button2 = _interopRequireDefault(_Button);
 
-	var _interaction = __webpack_require__(43);
+	var _interaction = __webpack_require__(54);
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -8195,41 +10360,41 @@ return /******/ (function(modules) { // webpackBootstrap
 	var propTypes = {
 
 	  // -- controlled props -----------
-	  value: _react2.default.PropTypes.number,
-	  onChange: _react2.default.PropTypes.func,
+	  value: _propTypes2.default.number,
+	  onChange: _propTypes2.default.func,
 	  //------------------------------------
 
-	  min: _react2.default.PropTypes.number,
-	  max: _react2.default.PropTypes.number,
-	  step: _react2.default.PropTypes.number,
+	  min: _propTypes2.default.number,
+	  max: _propTypes2.default.number,
+	  step: _propTypes2.default.number,
 
-	  precision: _react2.default.PropTypes.number,
+	  precision: _propTypes2.default.number,
 
-	  culture: _react2.default.PropTypes.string,
+	  culture: _propTypes2.default.string,
 
-	  format: _propTypes2.default.numberFormat,
+	  format: _propTypes4.default.numberFormat,
 
-	  name: _react2.default.PropTypes.string,
+	  name: _propTypes2.default.string,
 
-	  parse: _react2.default.PropTypes.func,
+	  parse: _propTypes2.default.func,
 
-	  autoFocus: _react2.default.PropTypes.bool,
-	  disabled: _propTypes2.default.disabled,
-	  readOnly: _propTypes2.default.readOnly,
+	  autoFocus: _propTypes2.default.bool,
+	  disabled: _propTypes4.default.disabled,
+	  readOnly: _propTypes4.default.readOnly,
 
-	  messages: _react2.default.PropTypes.shape({
-	    increment: _react2.default.PropTypes.string,
-	    decrement: _react2.default.PropTypes.string
+	  messages: _propTypes2.default.shape({
+	    increment: _propTypes2.default.string,
+	    decrement: _propTypes2.default.string
 	  }),
 
-	  placeholder: _react2.default.PropTypes.string
+	  placeholder: _propTypes2.default.string
 	};
 
-	var NumberPicker = _react2.default.createClass((_obj = {
+	var NumberPicker = (0, _createReactClass2.default)((_obj = {
 
 	  displayName: 'NumberPicker',
 
-	  mixins: [__webpack_require__(52), __webpack_require__(54), __webpack_require__(61), __webpack_require__(62)({
+	  mixins: [__webpack_require__(63), __webpack_require__(65), __webpack_require__(72), __webpack_require__(73)({
 	    willHandle: function willHandle(focused) {
 	      if (focused) this.focus();
 	    }
@@ -8425,9 +10590,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	module.exports = exports['default'];
 
-/***/ },
-/* 85 */
-/***/ function(module, exports) {
+/***/ }),
+/* 96 */
+/***/ (function(module, exports) {
 
 	"use strict";
 
@@ -8451,17 +10616,24 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 	module.exports = exports['default'];
 
-/***/ },
-/* 86 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 97 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	exports.__esModule = true;
+	exports.default = undefined;
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
+	var _class, _temp2;
+
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
@@ -8469,66 +10641,142 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 	var _localizers = __webpack_require__(17);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 	var getFormat = function getFormat(props) {
 	  return _localizers.number.getFormat('default', props.format);
 	};
 
 	var propTypes = {
-	  value: _react2.default.PropTypes.number,
-	  editing: _react2.default.PropTypes.bool,
-	  placeholder: _react2.default.PropTypes.string,
+	  value: _propTypes2.default.number,
+	  editing: _propTypes2.default.bool,
+	  placeholder: _propTypes2.default.string,
 
-	  format: _propTypes2.default.numberFormat,
+	  format: _propTypes4.default.numberFormat,
 
-	  parse: _react2.default.PropTypes.func,
-	  culture: _react2.default.PropTypes.string,
+	  parse: _propTypes2.default.func,
+	  culture: _propTypes2.default.string,
 
-	  min: _react2.default.PropTypes.number,
+	  min: _propTypes2.default.number,
 
-	  onChange: _react2.default.PropTypes.func.isRequired,
-	  onKeyDown: _react2.default.PropTypes.func
+	  onChange: _propTypes2.default.func.isRequired,
+	  onKeyDown: _propTypes2.default.func
 	};
 
-	exports.default = _react2.default.createClass({
+	var _default = (_temp2 = _class = function (_React$Component) {
+	  _inherits(_default, _React$Component);
 
-	  displayName: 'NumberPickerInput',
+	  function _default() {
+	    var _temp, _this, _ret;
 
-	  propTypes: propTypes,
+	    _classCallCheck(this, _default);
 
-	  getDefaultProps: function getDefaultProps() {
-	    return {
-	      value: null,
-	      editing: false
-	    };
-	  },
-	  getDefaultState: function getDefaultState() {
-	    var props = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this.props;
+	    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+	      args[_key] = arguments[_key];
+	    }
 
-	    var value = props.value,
-	        decimal = _localizers.number.decimalChar(null, props.culture),
-	        format = getFormat(props);
+	    return _ret = (_temp = (_this = _possibleConstructorReturn(this, _React$Component.call.apply(_React$Component, [this].concat(args))), _this), _this.getDefaultState = function () {
+	      var props = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _this.props;
 
-	    if (value == null || isNaN(props.value)) value = '';else value = props.editing ? ('' + value).replace('.', decimal) : _localizers.number.format(value, format, props.culture);
+	      var value = props.value,
+	          decimal = _localizers.number.decimalChar(null, props.culture),
+	          format = getFormat(props);
 
-	    return {
-	      stringValue: '' + value
-	    };
-	  },
-	  getInitialState: function getInitialState() {
-	    return this.getDefaultState();
-	  },
-	  componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
+	      if (value == null || isNaN(props.value)) value = '';else value = props.editing ? ('' + value).replace('.', decimal) : _localizers.number.format(value, format, props.culture);
+
+	      return {
+	        stringValue: '' + value
+	      };
+	    }, _this._change = function (e) {
+	      var val = e.target.value,
+	          number = _this._parse(e.target.value);
+
+	      var isIntermediate = _this.isIntermediateValue(number, val);
+
+	      if (val == null || val.trim() === '') {
+	        _this.current('');
+	        return _this.props.onChange(null);
+	      }
+
+	      if (!isIntermediate) {
+	        if (number !== _this.props.value) {
+	          return _this.props.onChange(number);
+	        }
+	      } else {
+	        _this.current(e.target.value);
+	      }
+	    }, _this._finish = function () {
+	      var str = _this.state.stringValue,
+	          number = _this._parse(str);
+
+	      // if number is below the min
+	      // we need to flush low values and decimal stops, onBlur means i'm done inputing
+	      if (_this.isIntermediateValue(number, str)) {
+	        if (isNaN(number)) {
+	          number = null;
+	        }
+	        _this.props.onChange(number);
+	      }
+	    }, _this._parse = function (strVal) {
+	      var culture = _this.props.culture,
+	          delimChar = _localizers.number.decimalChar(null, culture),
+	          userParse = _this.props.parse;
+
+	      if (userParse) return userParse(strVal, culture);
+
+	      strVal = strVal.replace(delimChar, '.');
+	      strVal = parseFloat(strVal);
+
+	      return strVal;
+	    }, _this.isIntermediateValue = function (num, str) {
+	      return !!(num < _this.props.min || _this.isSign(str) || _this.isAtDelimiter(num, str) || _this.isPaddedZeros(str));
+	    }, _this.isSign = function (val) {
+	      return (val || '').trim() === '-';
+	    }, _this.isPaddedZeros = function (str) {
+	      var localeChar = _localizers.number.decimalChar(null, _this.props.culture);
+
+	      var _str$split = str.split(localeChar),
+	          _ = _str$split[0],
+	          decimals = _str$split[1];
+
+	      return !!(decimals && decimals.match(/0+$/));
+	    }, _this.isAtDelimiter = function (num, str) {
+	      var props = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : _this.props;
+
+	      var localeChar = _localizers.number.decimalChar(null, props.culture),
+	          lastIndex = str.length - 1,
+	          char;
+
+	      if (str.length < 1) return false;
+
+	      char = str[lastIndex];
+
+	      return !!(char === localeChar && str.indexOf(char) === lastIndex);
+	    }, _this.isValid = function (num) {
+	      if (typeof num !== 'number' || isNaN(num)) return false;
+	      return num >= _this.props.min;
+	    }, _this.current = function (stringValue) {
+	      _this.setState({ stringValue: stringValue });
+	    }, _this.state = _this.getDefaultState(), _temp), _possibleConstructorReturn(_this, _ret);
+	  }
+
+	  _default.prototype.componentWillReceiveProps = function componentWillReceiveProps(nextProps) {
 	    this.setState(this.getDefaultState(nextProps));
-	  },
-	  render: function render() {
+	  };
+
+	  _default.prototype.render = function render() {
 	    var value = this.state.stringValue;
 	    var props = _3.default.omitOwnProps(this);
 
@@ -8544,95 +10792,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	      placeholder: this.props.placeholder,
 	      value: value
 	    }));
-	  },
-	  _change: function _change(e) {
-	    var val = e.target.value,
-	        number = this._parse(e.target.value);
-
-	    var isIntermediate = this.isIntermediateValue(number, val);
-
-	    if (val == null || val.trim() === '') {
-	      this.current('');
-	      return this.props.onChange(null);
-	    }
-
-	    if (!isIntermediate) {
-	      if (number !== this.props.value) {
-	        return this.props.onChange(number);
-	      }
-	    } else {
-	      this.current(e.target.value);
-	    }
-	  },
-	  _finish: function _finish() {
-	    var str = this.state.stringValue,
-	        number = this._parse(str);
-
-	    // if number is below the min
-	    // we need to flush low values and decimal stops, onBlur means i'm done inputing
-	    if (this.isIntermediateValue(number, str)) {
-	      if (isNaN(number)) {
-	        number = null;
-	      }
-	      this.props.onChange(number);
-	    }
-	  },
-	  _parse: function _parse(strVal) {
-	    var culture = this.props.culture,
-	        delimChar = _localizers.number.decimalChar(null, culture),
-	        userParse = this.props.parse;
-
-	    if (userParse) return userParse(strVal, culture);
-
-	    strVal = strVal.replace(delimChar, '.');
-	    strVal = parseFloat(strVal);
-
-	    return strVal;
-	  },
-	  isIntermediateValue: function isIntermediateValue(num, str) {
-	    return !!(num < this.props.min || this.isSign(str) || this.isAtDelimiter(num, str) || this.isPaddedZeros(str));
-	  },
-	  isSign: function isSign(val) {
-	    return (val || '').trim() === '-';
-	  },
-	  isPaddedZeros: function isPaddedZeros(str) {
-	    var localeChar = _localizers.number.decimalChar(null, this.props.culture);
-
-	    var _str$split = str.split(localeChar),
-	        _ = _str$split[0],
-	        decimals = _str$split[1];
-
-	    return !!(decimals && decimals.match(/0+$/));
-	  },
-	  isAtDelimiter: function isAtDelimiter(num, str) {
-	    var props = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : this.props;
-
-	    var localeChar = _localizers.number.decimalChar(null, props.culture),
-	        lastIndex = str.length - 1,
-	        char;
-
-	    if (str.length < 1) return false;
-
-	    char = str[lastIndex];
-
-	    return !!(char === localeChar && str.indexOf(char) === lastIndex);
-	  },
-	  isValid: function isValid(num) {
-	    if (typeof num !== 'number' || isNaN(num)) return false;
-	    return num >= this.props.min;
-	  },
-
+	  };
 
 	  //this intermediate state is for when one runs into the decimal or are typing the number
-	  current: function current(stringValue) {
-	    this.setState({ stringValue: stringValue });
-	  }
-	});
+
+
+	  return _default;
+	}(_react2.default.Component), _class.displayName = 'NumberPickerInput', _class.propTypes = propTypes, _class.defaultProps = {
+	  value: null,
+	  editing: false
+	}, _temp2);
+
+	exports.default = _default;
 	module.exports = exports['default'];
 
-/***/ },
-/* 87 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 98 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -8642,11 +10818,19 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _classnames = __webpack_require__(25);
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
@@ -8654,47 +10838,47 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _uncontrollable = __webpack_require__(49);
+	var _uncontrollable = __webpack_require__(60);
 
 	var _uncontrollable2 = _interopRequireDefault(_uncontrollable);
 
-	var _Widget = __webpack_require__(26);
+	var _Widget = __webpack_require__(37);
 
 	var _Widget2 = _interopRequireDefault(_Widget);
 
-	var _Popup = __webpack_require__(34);
+	var _Popup = __webpack_require__(45);
 
 	var _Popup2 = _interopRequireDefault(_Popup);
 
-	var _MultiselectInput = __webpack_require__(88);
+	var _MultiselectInput = __webpack_require__(99);
 
 	var _MultiselectInput2 = _interopRequireDefault(_MultiselectInput);
 
-	var _MultiselectTagList = __webpack_require__(89);
+	var _MultiselectTagList = __webpack_require__(100);
 
 	var _MultiselectTagList2 = _interopRequireDefault(_MultiselectTagList);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
-	var _List = __webpack_require__(40);
+	var _List = __webpack_require__(51);
 
 	var _List2 = _interopRequireDefault(_List);
 
-	var _ListGroupable = __webpack_require__(46);
+	var _ListGroupable = __webpack_require__(57);
 
 	var _ListGroupable2 = _interopRequireDefault(_ListGroupable);
 
-	var _validateListInterface = __webpack_require__(48);
+	var _validateListInterface = __webpack_require__(59);
 
 	var _validateListInterface2 = _interopRequireDefault(_validateListInterface);
 
-	var _dataHelpers = __webpack_require__(33);
+	var _dataHelpers = __webpack_require__(44);
 
-	var _interaction = __webpack_require__(43);
+	var _interaction = __webpack_require__(54);
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -8740,57 +10924,57 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var propTypes = _extends({}, _Popup2.default.propTypes, {
 
-	  data: _react2.default.PropTypes.array,
+	  data: _propTypes2.default.array,
 	  //-- controlled props --
-	  value: _react2.default.PropTypes.array,
-	  onChange: _react2.default.PropTypes.func,
+	  value: _propTypes2.default.array,
+	  onChange: _propTypes2.default.func,
 
-	  searchTerm: _react2.default.PropTypes.string,
-	  onSearch: _react2.default.PropTypes.func,
+	  searchTerm: _propTypes2.default.string,
+	  onSearch: _propTypes2.default.func,
 
-	  open: _react2.default.PropTypes.bool,
-	  onToggle: _react2.default.PropTypes.func,
+	  open: _propTypes2.default.bool,
+	  onToggle: _propTypes2.default.func,
 	  //-------------------------------------------
 
-	  valueField: _react2.default.PropTypes.string,
-	  textField: _propTypes2.default.accessor,
+	  valueField: _propTypes2.default.string,
+	  textField: _propTypes4.default.accessor,
 
-	  tagComponent: _propTypes2.default.elementType,
-	  itemComponent: _propTypes2.default.elementType,
-	  listComponent: _propTypes2.default.elementType,
+	  tagComponent: _propTypes4.default.elementType,
+	  itemComponent: _propTypes4.default.elementType,
+	  listComponent: _propTypes4.default.elementType,
 
-	  groupComponent: _propTypes2.default.elementType,
-	  groupBy: _propTypes2.default.accessor,
+	  groupComponent: _propTypes4.default.elementType,
+	  groupBy: _propTypes4.default.accessor,
 
-	  createComponent: _propTypes2.default.elementType,
+	  createComponent: _propTypes4.default.elementType,
 
-	  onSelect: _react2.default.PropTypes.func,
-	  onCreate: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.oneOf([false]), _react2.default.PropTypes.func]),
+	  onSelect: _propTypes2.default.func,
+	  onCreate: _propTypes2.default.oneOfType([_propTypes2.default.oneOf([false]), _propTypes2.default.func]),
 
-	  inputSize: _react2.default.PropTypes.func,
+	  inputSize: _propTypes2.default.func,
 
-	  busy: _react2.default.PropTypes.bool,
-	  dropUp: _react2.default.PropTypes.bool,
+	  busy: _propTypes2.default.bool,
+	  dropUp: _propTypes2.default.bool,
 
-	  placeholder: _react2.default.PropTypes.string,
+	  placeholder: _propTypes2.default.string,
 
-	  autoFocus: _react2.default.PropTypes.bool,
-	  disabled: _propTypes2.default.disabled.acceptsArray,
-	  readOnly: _propTypes2.default.readOnly.acceptsArray,
+	  autoFocus: _propTypes2.default.bool,
+	  disabled: _propTypes4.default.disabled.acceptsArray,
+	  readOnly: _propTypes4.default.readOnly.acceptsArray,
 
-	  messages: _react2.default.PropTypes.shape({
-	    open: _propTypes2.default.message,
-	    emptyList: _propTypes2.default.message,
-	    emptyFilter: _propTypes2.default.message,
-	    createNew: _propTypes2.default.message
+	  messages: _propTypes2.default.shape({
+	    open: _propTypes4.default.message,
+	    emptyList: _propTypes4.default.message,
+	    emptyFilter: _propTypes4.default.message,
+	    createNew: _propTypes4.default.message
 	  })
 	});
 
-	var Multiselect = _react2.default.createClass((_obj = {
+	var Multiselect = (0, _createReactClass2.default)((_obj = {
 
 	  displayName: 'Multiselect',
 
-	  mixins: [__webpack_require__(52), __webpack_require__(55), __webpack_require__(56), __webpack_require__(61), __webpack_require__(62)({
+	  mixins: [__webpack_require__(63), __webpack_require__(66), __webpack_require__(67), __webpack_require__(72), __webpack_require__(73)({
 	    willHandle: function willHandle(focused) {
 	      focused && this.focus();
 	    },
@@ -8801,7 +10985,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      if (focused && !this.props.open) this.open();
 	    }
-	  }), __webpack_require__(45)('input', function (key, id) {
+	  }), __webpack_require__(56)('input', function (key, id) {
 	    var myKey = this.props.ariaActiveDescendantKey;
 
 
@@ -9118,129 +11302,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  },
 	  handleInputInteraction: function handleInputInteraction() {
 	    this.open();
-	  },
-	  handleSelect: function handleSelect(data) {
-	    if (data === undefined) {
-	      if (this.props.onCreate) this.handleCreate(this.props.searchTerm);
-
-	      return;
-	    }
-	    (0, _widgetHelpers.notify)(this.props.onSelect, data);
-	    this.change(this.state.dataItems.concat(data));
-
-	    this.close();
-	    this.focus();
-	  },
-	  handleCreate: function handleCreate(tag) {
-	    if (tag.trim() === '') return;
-
-	    (0, _widgetHelpers.notify)(this.props.onCreate, tag);
-	    this.props.searchTerm && (0, _widgetHelpers.notify)(this.props.onSearch, ['']);
-
-	    this.close();
-	    this.focus();
-	  },
-	  handleKeyDown: function handleKeyDown(e) {
-	    var key = e.key,
-	        keyCode = e.keyCode,
-	        altKey = e.altKey,
-	        ctrlKey = e.ctrlKey,
-	        noSearch = !this.props.searchTerm && !this._deletingText,
-	        isOpen = this.props.open;
-	    var _state4 = this.state,
-	        focusedTag = _state4.focusedTag,
-	        focusedItem = _state4.focusedItem;
-	    var _refs = this.refs,
-	        list = _refs.list,
-	        tagList = _refs.tagList;
-
-	    var nullTag = { focusedTag: null };
-
-	    (0, _widgetHelpers.notify)(this.props.onKeyDown, [e]);
-
-	    if (e.defaultPrevented) return;
-
-	    if (key === 'ArrowDown') {
-	      var next = list.next(focusedItem),
-	          creating = this.shouldShowCreate() && focusedItem === next || focusedItem === null;
-
-	      next = creating ? null : next;
-
-	      e.preventDefault();
-	      if (isOpen) this.setState(_extends({ focusedItem: next }, nullTag));else this.open();
-	    } else if (key === 'ArrowUp') {
-	      var prev = focusedItem === null ? list.last() : list.prev(focusedItem);
-
-	      e.preventDefault();
-
-	      if (altKey) this.close();else if (isOpen) this.setState(_extends({ focusedItem: prev }, nullTag));
-	    } else if (key === 'End') {
-	      e.preventDefault();
-	      if (isOpen) this.setState(_extends({ focusedItem: list.last() }, nullTag));else tagList && this.setState({ focusedTag: tagList.last() });
-	    } else if (key === 'Home') {
-	      e.preventDefault();
-	      if (isOpen) this.setState(_extends({ focusedItem: list.first() }, nullTag));else tagList && this.setState({ focusedTag: tagList.first() });
-	    } else if (isOpen && keyCode === 13) {
-	      // using keyCode to ignore enter for japanese IME
-	      e.preventDefault();
-	      ctrlKey && this.props.onCreate || focusedItem === null ? this.handleCreate(this.props.searchTerm) : this.handleSelect(this.state.focusedItem);
-	    } else if (key === 'Escape') isOpen ? this.close() : tagList && this.setState(nullTag);else if (noSearch && key === 'ArrowLeft') tagList && this.setState({ focusedTag: tagList.prev(focusedTag) });else if (noSearch && key === 'ArrowRight') tagList && this.setState({ focusedTag: tagList.next(focusedTag) });else if (noSearch && key === 'Delete') tagList && tagList.remove(focusedTag);else if (noSearch && key === 'Backspace') tagList && tagList.removeNext();
-	  },
-	  change: function change(data) {
-	    (0, _widgetHelpers.notify)(this.props.onChange, [data]);
-	    (0, _widgetHelpers.notify)(this.props.onSearch, ['']);
-	  },
-	  focus: function focus() {
-	    this.refs.input && this.refs.input.focus();
-	  },
-	  open: function open() {
-	    if (!this.props.open) (0, _widgetHelpers.notify)(this.props.onToggle, true);
-	  },
-	  close: function close() {
-	    (0, _widgetHelpers.notify)(this.props.onToggle, false);
-	  },
-	  toggle: function toggle() {
-	    this.props.open ? this.close() : this.open();
-	  },
-	  process: function process(data, values, searchTerm) {
-	    var valueField = this.props.valueField;
-
-	    var items = data.filter(function (i) {
-	      return !values.some(function (v) {
-	        return (0, _dataHelpers.valueMatcher)(i, v, valueField);
-	      });
-	    });
-
-	    this._lengthWithoutValues = items.length;
-
-	    if (searchTerm) items = this.filter(items, searchTerm);
-
-	    return items;
-	  },
-	  shouldShowCreate: function shouldShowCreate() {
-	    var _props6 = this.props,
-	        textField = _props6.textField,
-	        searchTerm = _props6.searchTerm,
-	        onCreate = _props6.onCreate,
-	        caseSensitive = _props6.caseSensitive;
-
-
-	    if (!onCreate || !searchTerm) return false;
-
-	    var lower = function lower(text) {
-	      return caseSensitive ? text : text.toLowerCase();
-	    };
-	    var eq = function eq(v) {
-	      return lower((0, _dataHelpers.dataText)(v, textField)) === lower(searchTerm);
-	    };
-
-	    // if there is an exact match on textFields: "john" => { name: "john" }, don't show
-	    return !this._data().some(eq) && !this.state.dataItems.some(eq);
-	  },
-	  getPlaceholder: function getPlaceholder() {
-	    return (this.props.value || []).length ? '' : this.props.placeholder || '';
 	  }
-	}, (_applyDecoratedDescriptor(_obj, 'handleInputInteraction', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleInputInteraction'), _obj), _applyDecoratedDescriptor(_obj, 'handleSelect', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleSelect'), _obj), _applyDecoratedDescriptor(_obj, 'handleCreate', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleCreate'), _obj), _applyDecoratedDescriptor(_obj, 'handleKeyDown', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleKeyDown'), _obj), _applyDecoratedDescriptor(_obj, 'change', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'change'), _obj)), _obj));
+	}, (_applyDecoratedDescriptor(_obj, 'handleInputInteraction', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleInputInteraction'), _obj)), _obj));
 
 	function msgs(msgs) {
 	  return _extends({
@@ -9256,9 +11319,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = (0, _uncontrollable2.default)(Multiselect, { open: 'onToggle', value: 'onChange', searchTerm: 'onSearch' }, ['focus']);
 	module.exports = exports['default'];
 
-/***/ },
-/* 88 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 99 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -9268,7 +11331,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _class, _temp;
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
 
@@ -9276,13 +11343,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _compat = __webpack_require__(38);
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -9330,21 +11397,21 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  return MultiselectInput;
 	}(_react2.default.Component), _class.propTypes = {
-	  value: _react2.default.PropTypes.string,
-	  placeholder: _react2.default.PropTypes.string,
-	  maxLength: _react2.default.PropTypes.number,
-	  inputSize: _react2.default.PropTypes.func,
-	  onChange: _react2.default.PropTypes.func.isRequired,
+	  value: _propTypes2.default.string,
+	  placeholder: _propTypes2.default.string,
+	  maxLength: _propTypes2.default.number,
+	  inputSize: _propTypes2.default.func,
+	  onChange: _propTypes2.default.func.isRequired,
 
-	  disabled: _propTypes2.default.disabled,
-	  readOnly: _propTypes2.default.readOnly
+	  disabled: _propTypes4.default.disabled,
+	  readOnly: _propTypes4.default.readOnly
 	}, _temp);
 	exports.default = MultiselectInput;
 	module.exports = exports['default'];
 
-/***/ },
-/* 89 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 100 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -9352,27 +11419,35 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
+
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 	var _2 = __webpack_require__(19);
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _classnames = __webpack_require__(25);
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
-	var _dataHelpers = __webpack_require__(33);
+	var _dataHelpers = __webpack_require__(44);
 
-	var _interaction = __webpack_require__(43);
+	var _interaction = __webpack_require__(54);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -9380,24 +11455,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return id + '__option__' + idx;
 	};
 
-	exports.default = _react2.default.createClass({
+	exports.default = (0, _createReactClass2.default)({
 	  displayName: 'MultiselectTagList',
 
-
-	  mixins: [__webpack_require__(54), __webpack_require__(45)()],
+	  mixins: [__webpack_require__(65), __webpack_require__(56)()],
 
 	  propTypes: {
-	    value: _react2.default.PropTypes.array,
-	    focused: _react2.default.PropTypes.number,
+	    value: _propTypes2.default.array,
+	    focused: _propTypes2.default.number,
 
-	    valueField: _react2.default.PropTypes.string,
-	    textField: _propTypes2.default.accessor,
+	    valueField: _propTypes2.default.string,
+	    textField: _propTypes4.default.accessor,
 
-	    onDelete: _react2.default.PropTypes.func.isRequired,
-	    valueComponent: _react2.default.PropTypes.func,
+	    onDelete: _propTypes2.default.func.isRequired,
+	    valueComponent: _propTypes2.default.func,
 
-	    disabled: _propTypes2.default.disabled.acceptsArray,
-	    readOnly: _propTypes2.default.readOnly.acceptsArray
+	    disabled: _propTypes4.default.disabled.acceptsArray,
+	    readOnly: _propTypes4.default.readOnly.acceptsArray
 	  },
 
 	  getDefaultProps: function getDefaultProps() {
@@ -9530,9 +11604,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	module.exports = exports['default'];
 
-/***/ },
-/* 90 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ }),
+/* 101 */
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -9542,59 +11616,67 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _desc, _value, _obj;
 
-	var _react = __webpack_require__(20);
+	var _propTypes = __webpack_require__(20);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _react = __webpack_require__(29);
 
 	var _react2 = _interopRequireDefault(_react);
+
+	var _createReactClass = __webpack_require__(31);
+
+	var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 	var _2 = __webpack_require__(19);
 
 	var _3 = _interopRequireDefault(_2);
 
-	var _classnames = __webpack_require__(25);
+	var _classnames = __webpack_require__(36);
 
 	var _classnames2 = _interopRequireDefault(_classnames);
 
-	var _uncontrollable = __webpack_require__(49);
+	var _uncontrollable = __webpack_require__(60);
 
 	var _uncontrollable2 = _interopRequireDefault(_uncontrollable);
 
-	var _compat = __webpack_require__(38);
+	var _compat = __webpack_require__(49);
 
 	var _compat2 = _interopRequireDefault(_compat);
 
-	var _propTypes = __webpack_require__(31);
+	var _propTypes3 = __webpack_require__(42);
 
-	var _propTypes2 = _interopRequireDefault(_propTypes);
+	var _propTypes4 = _interopRequireDefault(_propTypes3);
 
-	var _List = __webpack_require__(40);
+	var _List = __webpack_require__(51);
 
 	var _List2 = _interopRequireDefault(_List);
 
-	var _ListGroupable = __webpack_require__(46);
+	var _ListGroupable = __webpack_require__(57);
 
 	var _ListGroupable2 = _interopRequireDefault(_ListGroupable);
 
-	var _ListOption = __webpack_require__(41);
+	var _ListOption = __webpack_require__(52);
 
 	var _ListOption2 = _interopRequireDefault(_ListOption);
 
-	var _Widget = __webpack_require__(26);
+	var _Widget = __webpack_require__(37);
 
 	var _Widget2 = _interopRequireDefault(_Widget);
 
-	var _validateListInterface = __webpack_require__(48);
+	var _validateListInterface = __webpack_require__(59);
 
 	var _validateListInterface2 = _interopRequireDefault(_validateListInterface);
 
-	var _scrollTo2 = __webpack_require__(57);
+	var _scrollTo2 = __webpack_require__(68);
 
 	var _scrollTo3 = _interopRequireDefault(_scrollTo2);
 
-	var _dataHelpers = __webpack_require__(33);
+	var _dataHelpers = __webpack_require__(44);
 
-	var _interaction = __webpack_require__(43);
+	var _interaction = __webpack_require__(54);
 
-	var _widgetHelpers = __webpack_require__(42);
+	var _widgetHelpers = __webpack_require__(53);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -9632,29 +11714,29 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var propTypes = {
 
-	  data: _react2.default.PropTypes.array,
-	  value: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.any, _react2.default.PropTypes.array]),
-	  onChange: _react2.default.PropTypes.func,
-	  onMove: _react2.default.PropTypes.func,
+	  data: _propTypes2.default.array,
+	  value: _propTypes2.default.oneOfType([_propTypes2.default.any, _propTypes2.default.array]),
+	  onChange: _propTypes2.default.func,
+	  onMove: _propTypes2.default.func,
 
-	  multiple: _react2.default.PropTypes.bool,
+	  multiple: _propTypes2.default.bool,
 
-	  itemComponent: _propTypes2.default.elementType,
-	  listComponent: _propTypes2.default.elementType,
+	  itemComponent: _propTypes4.default.elementType,
+	  listComponent: _propTypes4.default.elementType,
 
-	  valueField: _react2.default.PropTypes.string,
-	  textField: _propTypes2.default.accessor,
+	  valueField: _propTypes2.default.string,
+	  textField: _propTypes4.default.accessor,
 
-	  busy: _react2.default.PropTypes.bool,
+	  busy: _propTypes2.default.bool,
 
-	  filter: _react2.default.PropTypes.string,
-	  delay: _react2.default.PropTypes.number,
+	  filter: _propTypes2.default.string,
+	  delay: _propTypes2.default.number,
 
-	  disabled: _propTypes2.default.disabled.acceptsArray,
-	  readOnly: _propTypes2.default.readOnly.acceptsArray,
+	  disabled: _propTypes4.default.disabled.acceptsArray,
+	  readOnly: _propTypes4.default.readOnly.acceptsArray,
 
-	  messages: _react2.default.PropTypes.shape({
-	    emptyList: _react2.default.PropTypes.string
+	  messages: _propTypes2.default.shape({
+	    emptyList: _propTypes2.default.string
 	  })
 	};
 
@@ -9672,13 +11754,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return null;
 	}
 
-	var SelectList = _react2.default.createClass((_obj = {
+	var SelectList = (0, _createReactClass2.default)((_obj = {
 	  displayName: 'SelectList',
 
 
 	  propTypes: propTypes,
 
-	  mixins: [__webpack_require__(52), __webpack_require__(53), __webpack_require__(61), __webpack_require__(45)(), __webpack_require__(62)({
+	  mixins: [__webpack_require__(63), __webpack_require__(64), __webpack_require__(72), __webpack_require__(56)(), __webpack_require__(73)({
 	    didHandle: function didHandle(focused) {
 	      // the rigamarole here is to avoid flicker went clicking an item and
 	      // gaining focus at the same time.
@@ -9930,7 +12012,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function getListItem(parent) {
 
-	  return _react2.default.createClass({
+	  return (0, _createReactClass2.default)({
 
 	    displayName: 'SelectItem',
 
@@ -9989,7 +12071,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = (0, _uncontrollable2.default)(SelectList, { value: 'onChange' }, ['selectAll', 'focus']);
 	module.exports = exports['default'];
 
-/***/ }
+/***/ })
 /******/ ])
 });
 ;

--- a/lib/Calendar.js
+++ b/lib/Calendar.js
@@ -4,7 +4,7 @@ exports.__esModule = true;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _VIEW, _OPPOSITE_DIRECTION, _MULTIPLIER, _desc, _value, _obj; //values, omit
+var _VIEW, _OPPOSITE_DIRECTION, _MULTIPLIER, _desc, _value2, _obj; //values, omit
 
 
 var _propTypes = require('prop-types');
@@ -88,6 +88,8 @@ var _interaction = require('./util/interaction');
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
 function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) {
   var desc = {};
@@ -388,8 +390,97 @@ var Calendar = (0, _createReactClass2.default)((_obj = {
     }
 
     this.navigate(dir.DOWN, date);
+  },
+  changeCurrentDate: function changeCurrentDate(date) {
+    var currentDate = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : this.props.currentDate;
+
+    var inRangeDate = this.inRangeValue(date ? new Date(date) : currentDate);
+    if (_dates2.default.eq(inRangeDate, dateOrNull(currentDate), VIEW_UNIT[this.state.view])) return;
+    (0, _widgetHelpers.notify)(this.props.onCurrentDateChange, inRangeDate);
+  },
+  select: function select(date) {
+    var view = this.props.initialView,
+        slideDir = view !== this.state.view || _dates2.default.gt(date, this.state.currentDate) ? 'left' // move down to a the view
+    : 'right';
+
+    (0, _widgetHelpers.notify)(this.props.onChange, date);
+
+    if (this.isValidView(view) && _dates2.default.inRange(date, this.props.min, this.props.max, view)) {
+      this.focus();
+
+      this.changeCurrentDate(date);
+
+      this.setState({
+        slideDirection: slideDir,
+        view: view
+      });
+    }
+  },
+  nextDate: function nextDate(direction) {
+    var method = direction === dir.LEFT ? 'subtract' : 'add',
+        view = this.state.view,
+        unit = view === views.MONTH ? view : views.YEAR,
+        multi = MULTIPLIER[view] || 1;
+
+    return _dates2.default[method](this.props.currentDate, 1 * multi, unit);
+  },
+  handleKeyDown: function handleKeyDown(e) {
+    var ctrl = e.ctrlKey,
+        key = e.key,
+        direction = ARROWS_TO_DIRECTION[key],
+        current = this.props.currentDate,
+        view = this.state.view,
+        unit = VIEW_UNIT[view],
+        currentDate = current;
+
+    if (key === 'Enter') {
+      e.preventDefault();
+      return this.change(current);
+    }
+
+    if (direction) {
+      if (ctrl) {
+        e.preventDefault();
+        this.navigate(direction);
+      } else {
+        if (this.isRtl() && OPPOSITE_DIRECTION[direction]) direction = OPPOSITE_DIRECTION[direction];
+
+        currentDate = _dates2.default.move(currentDate, this.props.min, this.props.max, view, direction);
+
+        if (!_dates2.default.eq(current, currentDate, unit)) {
+          e.preventDefault();
+
+          if (_dates2.default.gt(currentDate, current, view)) this.navigate(dir.RIGHT, currentDate);else if (_dates2.default.lt(currentDate, current, view)) this.navigate(dir.LEFT, currentDate);else this.changeCurrentDate(currentDate);
+        }
+      }
+    }
+
+    (0, _widgetHelpers.notify)(this.props.onKeyDown, [e]);
+  },
+  _label: function _label() {
+    var _props2 = this.props,
+        culture = _props2.culture,
+        props = _objectWithoutProperties(_props2, ['culture']),
+        view = this.state.view,
+        dt = this.props.currentDate;
+
+    if (view === 'month') return _localizers.date.format(dt, format(props, 'header'), culture);else if (view === 'year') return _localizers.date.format(dt, format(props, 'year'), culture);else if (view === 'decade') return _localizers.date.format(_dates2.default.startOf(dt, 'decade'), format(props, 'decade'), culture);else if (view === 'century') return _localizers.date.format(_dates2.default.startOf(dt, 'century'), format(props, 'century'), culture);
+  },
+  inRangeValue: function inRangeValue(_value) {
+    var value = dateOrNull(_value);
+
+    if (value === null) return value;
+
+    return _dates2.default.max(_dates2.default.min(value, this.props.max), this.props.min);
+  },
+  isValidView: function isValidView(next) {
+    var bottom = VIEW_OPTIONS.indexOf(this.props.initialView),
+        top = VIEW_OPTIONS.indexOf(this.props.finalView),
+        current = VIEW_OPTIONS.indexOf(next);
+
+    return current >= bottom && current <= top;
   }
-}, (_applyDecoratedDescriptor(_obj, 'navigate', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'navigate'), _obj), _applyDecoratedDescriptor(_obj, 'change', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'change'), _obj)), _obj));
+}, (_applyDecoratedDescriptor(_obj, 'navigate', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'navigate'), _obj), _applyDecoratedDescriptor(_obj, 'change', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'change'), _obj), _applyDecoratedDescriptor(_obj, 'select', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'select'), _obj), _applyDecoratedDescriptor(_obj, 'handleKeyDown', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleKeyDown'), _obj)), _obj));
 
 function dateOrNull(dt) {
   if (dt && !isNaN(dt.getTime())) return dt;

--- a/lib/Calendar.js
+++ b/lib/Calendar.js
@@ -4,12 +4,20 @@ exports.__esModule = true;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _VIEW, _OPPOSITE_DIRECTION, _MULTIPLIER, _desc, _value2, _obj; //values, omit
+var _VIEW, _OPPOSITE_DIRECTION, _MULTIPLIER, _desc, _value, _obj; //values, omit
 
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _classnames = require('classnames');
 
@@ -49,9 +57,9 @@ var _Century2 = _interopRequireDefault(_Century);
 
 var _localizers = require('./util/localizers');
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _uncontrollable = require('uncontrollable');
 
@@ -80,8 +88,6 @@ var _interaction = require('./util/interaction');
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
 function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) {
   var desc = {};
@@ -148,56 +154,56 @@ var format = function format(props, f) {
 
 var propTypes = {
 
-  disabled: _propTypes2.default.disabled,
-  readOnly: _propTypes2.default.readOnly,
+  disabled: _propTypes4.default.disabled,
+  readOnly: _propTypes4.default.readOnly,
 
-  onChange: _react2.default.PropTypes.func,
-  value: _react2.default.PropTypes.instanceOf(Date),
+  onChange: _propTypes2.default.func,
+  value: _propTypes2.default.instanceOf(Date),
 
-  min: _react2.default.PropTypes.instanceOf(Date),
-  max: _react2.default.PropTypes.instanceOf(Date),
+  min: _propTypes2.default.instanceOf(Date),
+  max: _propTypes2.default.instanceOf(Date),
 
-  currentDate: _react2.default.PropTypes.instanceOf(Date),
-  onCurrentDateChange: _react2.default.PropTypes.func,
+  currentDate: _propTypes2.default.instanceOf(Date),
+  onCurrentDateChange: _propTypes2.default.func,
 
-  view: _react2.default.PropTypes.oneOf(VIEW_OPTIONS),
-  initialView: _react2.default.PropTypes.oneOf(VIEW_OPTIONS),
+  view: _propTypes2.default.oneOf(VIEW_OPTIONS),
+  initialView: _propTypes2.default.oneOf(VIEW_OPTIONS),
 
   finalView: function finalView(props, propName, componentName) {
     for (var _len = arguments.length, args = Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
       args[_key - 3] = arguments[_key];
     }
 
-    var err = _react2.default.PropTypes.oneOf(VIEW_OPTIONS).apply(undefined, [props, propName, componentName].concat(args));
+    var err = _propTypes2.default.oneOf(VIEW_OPTIONS).apply(undefined, [props, propName, componentName].concat(args));
 
     if (err) return err;
     if (VIEW_OPTIONS.indexOf(props[propName]) < VIEW_OPTIONS.indexOf(props.initialView)) return new Error(('The `' + propName + '` prop: `' + props[propName] + '` cannot be \'lower\' than the `initialView`\n        prop. This creates a range that cannot be rendered.').replace(/\n\t/g, ''));
   },
 
 
-  onViewChange: _react2.default.PropTypes.func,
-  onNavigate: _react2.default.PropTypes.func,
-  culture: _react2.default.PropTypes.string,
-  footer: _react2.default.PropTypes.bool,
+  onViewChange: _propTypes2.default.func,
+  onNavigate: _propTypes2.default.func,
+  culture: _propTypes2.default.string,
+  footer: _propTypes2.default.bool,
 
-  dayComponent: _propTypes2.default.elementType,
-  headerFormat: _propTypes2.default.dateFormat,
-  footerFormat: _propTypes2.default.dateFormat,
+  dayComponent: _propTypes4.default.elementType,
+  headerFormat: _propTypes4.default.dateFormat,
+  footerFormat: _propTypes4.default.dateFormat,
 
-  dayFormat: _propTypes2.default.dateFormat,
-  dateFormat: _propTypes2.default.dateFormat,
-  monthFormat: _propTypes2.default.dateFormat,
-  yearFormat: _propTypes2.default.dateFormat,
-  decadeFormat: _propTypes2.default.dateFormat,
-  centuryFormat: _propTypes2.default.dateFormat,
+  dayFormat: _propTypes4.default.dateFormat,
+  dateFormat: _propTypes4.default.dateFormat,
+  monthFormat: _propTypes4.default.dateFormat,
+  yearFormat: _propTypes4.default.dateFormat,
+  decadeFormat: _propTypes4.default.dateFormat,
+  centuryFormat: _propTypes4.default.dateFormat,
 
-  messages: _react2.default.PropTypes.shape({
-    moveBack: _react2.default.PropTypes.string,
-    moveForward: _react2.default.PropTypes.string
+  messages: _propTypes2.default.shape({
+    moveBack: _propTypes2.default.string,
+    moveForward: _propTypes2.default.string
   })
 };
 
-var Calendar = _react2.default.createClass((_obj = {
+var Calendar = (0, _createReactClass2.default)((_obj = {
 
   displayName: 'Calendar',
 
@@ -382,97 +388,8 @@ var Calendar = _react2.default.createClass((_obj = {
     }
 
     this.navigate(dir.DOWN, date);
-  },
-  changeCurrentDate: function changeCurrentDate(date) {
-    var currentDate = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : this.props.currentDate;
-
-    var inRangeDate = this.inRangeValue(date ? new Date(date) : currentDate);
-    if (_dates2.default.eq(inRangeDate, dateOrNull(currentDate), VIEW_UNIT[this.state.view])) return;
-    (0, _widgetHelpers.notify)(this.props.onCurrentDateChange, inRangeDate);
-  },
-  select: function select(date) {
-    var view = this.props.initialView,
-        slideDir = view !== this.state.view || _dates2.default.gt(date, this.state.currentDate) ? 'left' // move down to a the view
-    : 'right';
-
-    (0, _widgetHelpers.notify)(this.props.onChange, date);
-
-    if (this.isValidView(view) && _dates2.default.inRange(date, this.props.min, this.props.max, view)) {
-      this.focus();
-
-      this.changeCurrentDate(date);
-
-      this.setState({
-        slideDirection: slideDir,
-        view: view
-      });
-    }
-  },
-  nextDate: function nextDate(direction) {
-    var method = direction === dir.LEFT ? 'subtract' : 'add',
-        view = this.state.view,
-        unit = view === views.MONTH ? view : views.YEAR,
-        multi = MULTIPLIER[view] || 1;
-
-    return _dates2.default[method](this.props.currentDate, 1 * multi, unit);
-  },
-  handleKeyDown: function handleKeyDown(e) {
-    var ctrl = e.ctrlKey,
-        key = e.key,
-        direction = ARROWS_TO_DIRECTION[key],
-        current = this.props.currentDate,
-        view = this.state.view,
-        unit = VIEW_UNIT[view],
-        currentDate = current;
-
-    if (key === 'Enter') {
-      e.preventDefault();
-      return this.change(current);
-    }
-
-    if (direction) {
-      if (ctrl) {
-        e.preventDefault();
-        this.navigate(direction);
-      } else {
-        if (this.isRtl() && OPPOSITE_DIRECTION[direction]) direction = OPPOSITE_DIRECTION[direction];
-
-        currentDate = _dates2.default.move(currentDate, this.props.min, this.props.max, view, direction);
-
-        if (!_dates2.default.eq(current, currentDate, unit)) {
-          e.preventDefault();
-
-          if (_dates2.default.gt(currentDate, current, view)) this.navigate(dir.RIGHT, currentDate);else if (_dates2.default.lt(currentDate, current, view)) this.navigate(dir.LEFT, currentDate);else this.changeCurrentDate(currentDate);
-        }
-      }
-    }
-
-    (0, _widgetHelpers.notify)(this.props.onKeyDown, [e]);
-  },
-  _label: function _label() {
-    var _props2 = this.props,
-        culture = _props2.culture,
-        props = _objectWithoutProperties(_props2, ['culture']),
-        view = this.state.view,
-        dt = this.props.currentDate;
-
-    if (view === 'month') return _localizers.date.format(dt, format(props, 'header'), culture);else if (view === 'year') return _localizers.date.format(dt, format(props, 'year'), culture);else if (view === 'decade') return _localizers.date.format(_dates2.default.startOf(dt, 'decade'), format(props, 'decade'), culture);else if (view === 'century') return _localizers.date.format(_dates2.default.startOf(dt, 'century'), format(props, 'century'), culture);
-  },
-  inRangeValue: function inRangeValue(_value) {
-    var value = dateOrNull(_value);
-
-    if (value === null) return value;
-
-    return _dates2.default.max(_dates2.default.min(value, this.props.max), this.props.min);
-  },
-  isValidView: function isValidView(next) {
-    var bottom = VIEW_OPTIONS.indexOf(this.props.initialView),
-        top = VIEW_OPTIONS.indexOf(this.props.finalView),
-        current = VIEW_OPTIONS.indexOf(next);
-
-    return current >= bottom && current <= top;
   }
-}, (_applyDecoratedDescriptor(_obj, 'navigate', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'navigate'), _obj), _applyDecoratedDescriptor(_obj, 'change', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'change'), _obj), _applyDecoratedDescriptor(_obj, 'select', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'select'), _obj), _applyDecoratedDescriptor(_obj, 'handleKeyDown', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleKeyDown'), _obj)), _obj));
+}, (_applyDecoratedDescriptor(_obj, 'navigate', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'navigate'), _obj), _applyDecoratedDescriptor(_obj, 'change', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'change'), _obj)), _obj));
 
 function dateOrNull(dt) {
   if (dt && !isNaN(dt.getTime())) return dt;

--- a/lib/CalendarView.js
+++ b/lib/CalendarView.js
@@ -6,6 +6,10 @@ var _class, _temp2;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -153,16 +157,16 @@ var CalendarViewCell = (_temp2 = _class = function (_React$Component2) {
 
   return CalendarViewCell;
 }(_react2.default.Component), _class.propTypes = {
-  id: _react2.default.PropTypes.string,
-  label: _react2.default.PropTypes.string,
-  today: _react2.default.PropTypes.instanceOf(Date),
-  selected: _react2.default.PropTypes.instanceOf(Date),
-  focused: _react2.default.PropTypes.instanceOf(Date),
-  min: _react2.default.PropTypes.instanceOf(Date),
-  max: _react2.default.PropTypes.instanceOf(Date),
-  unit: _react2.default.PropTypes.oneOf(['day'].concat(VIEW_UNITS)),
-  viewUnit: _react2.default.PropTypes.oneOf(VIEW_UNITS),
-  onChange: _react2.default.PropTypes.func.isRequired
+  id: _propTypes2.default.string,
+  label: _propTypes2.default.string,
+  today: _propTypes2.default.instanceOf(Date),
+  selected: _propTypes2.default.instanceOf(Date),
+  focused: _propTypes2.default.instanceOf(Date),
+  min: _propTypes2.default.instanceOf(Date),
+  max: _propTypes2.default.instanceOf(Date),
+  unit: _propTypes2.default.oneOf(['day'].concat(VIEW_UNITS)),
+  viewUnit: _propTypes2.default.oneOf(VIEW_UNITS),
+  onChange: _propTypes2.default.func.isRequired
 }, _temp2);
 
 

--- a/lib/Century.js
+++ b/lib/Century.js
@@ -2,9 +2,17 @@
 
 exports.__esModule = true;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _CalendarView = require('./CalendarView');
 
@@ -20,9 +28,9 @@ var _2 = require('./util/_');
 
 var _3 = _interopRequireDefault(_2);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _widgetHelpers = require('./util/widgetHelpers');
 
@@ -37,17 +45,17 @@ var optionId = function optionId(id, date) {
 };
 
 var propTypes = {
-  culture: _react2.default.PropTypes.string,
-  today: _react2.default.PropTypes.instanceOf(Date),
-  value: _react2.default.PropTypes.instanceOf(Date),
-  focused: _react2.default.PropTypes.instanceOf(Date),
-  min: _react2.default.PropTypes.instanceOf(Date),
-  max: _react2.default.PropTypes.instanceOf(Date),
-  onChange: _react2.default.PropTypes.func.isRequired,
-  decadeFormat: _propTypes2.default.dateFormat
+  culture: _propTypes2.default.string,
+  today: _propTypes2.default.instanceOf(Date),
+  value: _propTypes2.default.instanceOf(Date),
+  focused: _propTypes2.default.instanceOf(Date),
+  min: _propTypes2.default.instanceOf(Date),
+  max: _propTypes2.default.instanceOf(Date),
+  onChange: _propTypes2.default.func.isRequired,
+  decadeFormat: _propTypes4.default.dateFormat
 };
 
-exports.default = _react2.default.createClass({
+exports.default = (0, _createReactClass2.default)({
 
   displayName: 'CenturyView',
 

--- a/lib/Combobox.js
+++ b/lib/Combobox.js
@@ -6,9 +6,17 @@ var _desc, _value, _obj;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _classnames = require('classnames');
 
@@ -42,9 +50,9 @@ var _compat = require('./util/compat');
 
 var _compat2 = _interopRequireDefault(_compat);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _List = require('./List');
 
@@ -106,48 +114,48 @@ var defaultSuggest = function defaultSuggest(f) {
 var propTypes = _extends({}, _Popup2.default.propTypes, {
 
   //-- controlled props -----------
-  value: _react2.default.PropTypes.any,
-  onChange: _react2.default.PropTypes.func,
-  open: _react2.default.PropTypes.bool,
-  onToggle: _react2.default.PropTypes.func,
+  value: _propTypes2.default.any,
+  onChange: _propTypes2.default.func,
+  open: _propTypes2.default.bool,
+  onToggle: _propTypes2.default.func,
   //------------------------------------
 
-  itemComponent: _propTypes2.default.elementType,
-  listComponent: _propTypes2.default.elementType,
+  itemComponent: _propTypes4.default.elementType,
+  listComponent: _propTypes4.default.elementType,
 
-  groupComponent: _propTypes2.default.elementType,
-  groupBy: _propTypes2.default.accessor,
+  groupComponent: _propTypes4.default.elementType,
+  groupBy: _propTypes4.default.accessor,
 
-  data: _react2.default.PropTypes.array,
-  valueField: _react2.default.PropTypes.string,
-  textField: _propTypes2.default.accessor,
-  name: _react2.default.PropTypes.string,
+  data: _propTypes2.default.array,
+  valueField: _propTypes2.default.string,
+  textField: _propTypes4.default.accessor,
+  name: _propTypes2.default.string,
 
-  onSelect: _react2.default.PropTypes.func,
+  onSelect: _propTypes2.default.func,
 
-  autoFocus: _react2.default.PropTypes.bool,
-  disabled: _propTypes2.default.disabled.acceptsArray,
-  readOnly: _propTypes2.default.readOnly.acceptsArray,
+  autoFocus: _propTypes2.default.bool,
+  disabled: _propTypes4.default.disabled.acceptsArray,
+  readOnly: _propTypes4.default.readOnly.acceptsArray,
 
-  suggest: _propTypes2.default.filter,
-  filter: _propTypes2.default.filter,
+  suggest: _propTypes4.default.filter,
+  filter: _propTypes4.default.filter,
 
-  busy: _react2.default.PropTypes.bool,
+  busy: _propTypes2.default.bool,
 
-  dropUp: _react2.default.PropTypes.bool,
-  duration: _react2.default.PropTypes.number,
-  delay: _react2.default.PropTypes.number,
+  dropUp: _propTypes2.default.bool,
+  duration: _propTypes2.default.number,
+  delay: _propTypes2.default.number,
 
-  placeholder: _react2.default.PropTypes.string,
+  placeholder: _propTypes2.default.string,
 
-  messages: _react2.default.PropTypes.shape({
-    open: _propTypes2.default.message,
-    emptyList: _propTypes2.default.message,
-    emptyFilter: _propTypes2.default.message
+  messages: _propTypes2.default.shape({
+    open: _propTypes4.default.message,
+    emptyList: _propTypes4.default.message,
+    emptyFilter: _propTypes4.default.message
   })
 });
 
-var ComboBox = _react2.default.createClass((_obj = {
+var ComboBox = (0, _createReactClass2.default)((_obj = {
 
   displayName: 'ComboBox',
 
@@ -368,119 +376,8 @@ var ComboBox = _react2.default.createClass((_obj = {
     (0, _widgetHelpers.notify)(this.props.onSelect, data);
     this.change(data);
     this.focus();
-  },
-  handleInputKeyDown: function handleInputKeyDown(e) {
-    this._deleting = e.key === 'Backspace' || e.key === 'Delete';
-    this._isTyping = true;
-  },
-  handleInputChange: function handleInputChange(e) {
-    var _props5 = this.props,
-        data = _props5.data,
-        textField = _props5.textField;
-
-
-    var shouldSuggest = !!this.props.suggest,
-        strVal = e.target.value,
-        suggestion;
-
-    suggestion = this._deleting || !shouldSuggest ? strVal : this.suggest(this._data(), strVal);
-
-    suggestion = suggestion || strVal;
-
-    data = _3.default.find(data, function (item) {
-      return (0, _dataHelpers.dataText)(item, textField).toLowerCase() === suggestion.toLowerCase();
-    });
-
-    this.change(!this._deleting && data ? data : strVal, true);
-
-    this.open();
-  },
-  focus: function focus() {
-    this.refs.input && this.refs.input.focus();
-  },
-  handleKeyDown: function handleKeyDown(e) {
-    var self = this,
-        key = e.key,
-        alt = e.altKey,
-        list = this.refs.list,
-        focusedItem = this.state.focusedItem,
-        selectedItem = this.state.selectedItem,
-        isOpen = this.props.open;
-
-    (0, _widgetHelpers.notify)(this.props.onKeyDown, [e]);
-    if (e.defaultPrevented) return;
-
-    if (key === 'End') {
-      if (isOpen) this.setState({ focusedItem: list.last() });else select(list.last(), true);
-    } else if (key === 'Home') {
-      if (isOpen) this.setState({ focusedItem: list.first() });else select(list.first(), true);
-    } else if (key === 'Escape' && isOpen) this.close();else if (key === 'Enter' && isOpen) {
-      e.preventDefault();
-      select(this.state.focusedItem, true);
-    } else if (key === 'ArrowDown') {
-      if (alt) this.open();else {
-        if (isOpen) this.setState({ focusedItem: list.next(focusedItem) });else select(list.next(selectedItem), true);
-      }
-    } else if (key === 'ArrowUp') {
-      if (alt) this.close();else {
-        if (isOpen) this.setState({ focusedItem: list.prev(focusedItem) });else select(list.prev(selectedItem), true);
-      }
-    }
-
-    function select(item, fromList) {
-      if (!item) return self.change(_compat2.default.findDOMNode(self.refs.input).value, false);
-
-      self.refs.input.accept(true); //removes caret
-
-      if (fromList) return self.handleSelect(item);
-
-      self.change(item, false);
-    }
-  },
-  change: function change(data, typing) {
-    this._typedChange = !!typing;
-    (0, _widgetHelpers.notify)(this.props.onChange, data);
-  },
-  open: function open() {
-    if (!this.props.open) (0, _widgetHelpers.notify)(this.props.onToggle, true);
-  },
-  close: function close() {
-    if (this.props.open) (0, _widgetHelpers.notify)(this.props.onToggle, false);
-  },
-  toggle: function toggle() {
-    this.focus();
-
-    this.props.open ? this.close() : this.open();
-  },
-  suggest: function suggest(data, value) {
-    var _props6 = this.props,
-        textField = _props6.textField,
-        suggest = _props6.suggest,
-        minLength = _props6.minLength;
-
-
-    var word = (0, _dataHelpers.dataText)(value, textField),
-        suggestion;
-
-    suggest = defaultSuggest(suggest);
-
-    if (!(word || '').trim() || word.length < (minLength || 1)) return '';
-
-    suggestion = typeof value === 'string' ? _3.default.find(data, getFilter(suggest, word, textField)) : value;
-
-    if (suggestion && (!this.state || !this.state.deleting)) return (0, _dataHelpers.dataText)(suggestion, textField);
-
-    return '';
-  },
-  _data: function _data() {
-    return this.state.processedData;
-  },
-  process: function process(data, values, searchTerm) {
-    if (this.props.filter && searchTerm) data = this.filter(data, searchTerm);
-
-    return data;
   }
-}, (_applyDecoratedDescriptor(_obj, 'handleSelect', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleSelect'), _obj), _applyDecoratedDescriptor(_obj, 'handleKeyDown', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleKeyDown'), _obj), _applyDecoratedDescriptor(_obj, 'toggle', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'toggle'), _obj)), _obj));
+}, (_applyDecoratedDescriptor(_obj, 'handleSelect', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleSelect'), _obj)), _obj));
 
 exports.default = (0, _uncontrollable2.default)(ComboBox, { open: 'onToggle', value: 'onChange' }, ['focus']);
 

--- a/lib/ComboboxInput.js
+++ b/lib/ComboboxInput.js
@@ -1,8 +1,15 @@
 'use strict';
 
 exports.__esModule = true;
+exports.default = undefined;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _class, _temp2;
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _react = require('react');
 
@@ -28,17 +35,51 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-exports.default = _react2.default.createClass({
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-  displayName: 'ComboboxInput',
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-  propTypes: {
-    value: _react2.default.PropTypes.string,
-    suggest: _react2.default.PropTypes.bool,
-    onChange: _react2.default.PropTypes.func.isRequired
-  },
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-  componentDidUpdate: function componentDidUpdate() {
+var _default = (_temp2 = _class = function (_React$Component) {
+  _inherits(_default, _React$Component);
+
+  function _default() {
+    var _temp, _this, _ret;
+
+    _classCallCheck(this, _default);
+
+    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, _React$Component.call.apply(_React$Component, [this].concat(args))), _this), _this.isSuggesting = function () {
+      var val = _this.props.value,
+          isSuggestion = _this._last != null && val.toLowerCase().indexOf(_this._last.toLowerCase()) !== -1;
+
+      return _this.props.suggest && isSuggestion;
+    }, _this.accept = function (removeCaret) {
+      var val = _compat2.default.findDOMNode(_this).value || '',
+          end = val.length;
+
+      _this._last = null;
+      removeCaret && (0, _caret2.default)(_compat2.default.findDOMNode(_this), end, end);
+    }, _this.handleChange = function (e) {
+      var val = e.target.value,
+          pl = !!_this.props.placeholder;
+
+      // IE fires input events when setting/unsetting placeholders.
+      // issue #112
+      if (pl && !val && val === (_this.props.value || '')) return;
+
+      _this._last = val;
+      _this.props.onChange(e, val);
+    }, _this.focus = function () {
+      _compat2.default.findDOMNode(_this).focus();
+    }, _temp), _possibleConstructorReturn(_this, _ret);
+  }
+
+  _default.prototype.componentDidUpdate = function componentDidUpdate() {
     var input = _compat2.default.findDOMNode(this),
         val = this.props.value;
 
@@ -50,13 +91,9 @@ exports.default = _react2.default.createClass({
         (0, _caret2.default)(input, start, start + end);
       }
     }
-  },
-  getDefaultProps: function getDefaultProps() {
-    return {
-      value: ''
-    };
-  },
-  render: function render() {
+  };
+
+  _default.prototype.render = function render() {
     var _props = this.props,
         onKeyDown = _props.onKeyDown,
         props = _objectWithoutProperties(_props, ['onKeyDown']);
@@ -67,33 +104,16 @@ exports.default = _react2.default.createClass({
       onKeyDown: onKeyDown,
       onChange: this.handleChange
     }));
-  },
-  isSuggesting: function isSuggesting() {
-    var val = this.props.value,
-        isSuggestion = this._last != null && val.toLowerCase().indexOf(this._last.toLowerCase()) !== -1;
+  };
 
-    return this.props.suggest && isSuggestion;
-  },
-  accept: function accept(removeCaret) {
-    var val = _compat2.default.findDOMNode(this).value || '',
-        end = val.length;
+  return _default;
+}(_react2.default.Component), _class.displayName = 'ComboboxInput', _class.propTypes = {
+  value: _propTypes2.default.string,
+  suggest: _propTypes2.default.bool,
+  onChange: _propTypes2.default.func.isRequired
+}, _class.defaultProps = {
+  value: ''
+}, _temp2);
 
-    this._last = null;
-    removeCaret && (0, _caret2.default)(_compat2.default.findDOMNode(this), end, end);
-  },
-  handleChange: function handleChange(e) {
-    var val = e.target.value,
-        pl = !!this.props.placeholder;
-
-    // IE fires input events when setting/unsetting placeholders.
-    // issue #112
-    if (pl && !val && val === (this.props.value || '')) return;
-
-    this._last = val;
-    this.props.onChange(e, val);
-  },
-  focus: function focus() {
-    _compat2.default.findDOMNode(this).focus();
-  }
-});
+exports.default = _default;
 module.exports = exports['default'];

--- a/lib/DateTimePicker.js
+++ b/lib/DateTimePicker.js
@@ -6,6 +6,10 @@ var _desc, _value, _obj;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; //pick, omit, has
 
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
 var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
@@ -231,7 +235,7 @@ var DateTimePicker = (0, _createReactClass2.default)((_obj = {
     var focused = this.state.focused;
 
 
-    return React.createElement(_DateTimePickerInput2.default, {
+    return _react2.default.createElement(_DateTimePickerInput2.default, {
       id: id,
       ref: 'valueInput',
       role: 'combobox',
@@ -268,17 +272,17 @@ var DateTimePicker = (0, _createReactClass2.default)((_obj = {
       return null;
     }
 
-    return React.createElement(
+    return _react2.default.createElement(
       'span',
       { className: 'rw-select' },
-      calendar && React.createElement(_Button2.default, {
+      calendar && _react2.default.createElement(_Button2.default, {
         icon: 'calendar',
         className: 'rw-btn-calendar',
         label: messages.calendarButton,
         disabled: !!(disabled || readOnly),
         onClick: this._click.bind(null, _constants.datePopups.CALENDAR)
       }),
-      time && React.createElement(_Button2.default, {
+      time && _react2.default.createElement(_Button2.default, {
         icon: 'clock-o',
         className: 'rw-btn-time',
         label: messages.timeButton,
@@ -299,7 +303,7 @@ var DateTimePicker = (0, _createReactClass2.default)((_obj = {
 
     var calendarProps = _3.default.pickProps(this.props, Calendar);
 
-    return React.createElement(
+    return _react2.default.createElement(
       _Popup2.default,
       {
         dropUp: dropUp,
@@ -307,7 +311,7 @@ var DateTimePicker = (0, _createReactClass2.default)((_obj = {
         open: open === _constants.datePopups.CALENDAR,
         className: 'rw-calendar-popup'
       },
-      React.createElement(Calendar, _extends({}, calendarProps, {
+      _react2.default.createElement(Calendar, _extends({}, calendarProps, {
         ref: 'calPopup',
         id: id,
         tabIndex: '-1',
@@ -343,7 +347,7 @@ var DateTimePicker = (0, _createReactClass2.default)((_obj = {
 
     var timeListProps = _3.default.pickProps(this.props, _TimeList2.default);
 
-    return React.createElement(
+    return _react2.default.createElement(
       _Popup2.default,
       {
         dropUp: dropUp,
@@ -353,10 +357,10 @@ var DateTimePicker = (0, _createReactClass2.default)((_obj = {
           return _this2.refs.timePopup.forceUpdate();
         }
       },
-      React.createElement(
+      _react2.default.createElement(
         'div',
         null,
-        React.createElement(_TimeList2.default, _extends({}, timeListProps, {
+        _react2.default.createElement(_TimeList2.default, _extends({}, timeListProps, {
           ref: 'timePopup',
           id: id,
           format: timeFormat,
@@ -398,7 +402,7 @@ var DateTimePicker = (0, _createReactClass2.default)((_obj = {
     if (calendar) owns += dateListID;
     if (time) owns += ' ' + timeListID;
 
-    return React.createElement(
+    return _react2.default.createElement(
       _Widget2.default,
       _extends({}, elementProps, {
         open: !!open,

--- a/lib/DateTimePicker.js
+++ b/lib/DateTimePicker.js
@@ -6,9 +6,13 @@ var _desc, _value, _obj;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; //pick, omit, has
 
-var _react = require('react');
+var _propTypes = require('prop-types');
 
-var _react2 = _interopRequireDefault(_react);
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _invariant = require('invariant');
 
@@ -62,9 +66,9 @@ var _Button = require('./Button');
 
 var _Button2 = _interopRequireDefault(_Button);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _uncontrollable = require('uncontrollable');
 
@@ -114,55 +118,55 @@ var viewEnum = Object.keys(_constants.calendarViews).map(function (k) {
 var propTypes = _extends({}, Calendar.propTypes, {
 
   //-- controlled props -----------
-  value: _react2.default.PropTypes.instanceOf(Date),
-  onChange: _react2.default.PropTypes.func,
-  open: _react2.default.PropTypes.oneOf([false, _constants.datePopups.TIME, _constants.datePopups.CALENDAR]),
-  onToggle: _react2.default.PropTypes.func,
-  currentDate: _react2.default.PropTypes.instanceOf(Date),
-  onCurrentDateChange: _react2.default.PropTypes.func,
+  value: _propTypes2.default.instanceOf(Date),
+  onChange: _propTypes2.default.func,
+  open: _propTypes2.default.oneOf([false, _constants.datePopups.TIME, _constants.datePopups.CALENDAR]),
+  onToggle: _propTypes2.default.func,
+  currentDate: _propTypes2.default.instanceOf(Date),
+  onCurrentDateChange: _propTypes2.default.func,
   //------------------------------------
 
-  onSelect: _react2.default.PropTypes.func,
+  onSelect: _propTypes2.default.func,
 
-  min: _react2.default.PropTypes.instanceOf(Date),
-  max: _react2.default.PropTypes.instanceOf(Date),
+  min: _propTypes2.default.instanceOf(Date),
+  max: _propTypes2.default.instanceOf(Date),
 
-  culture: _react2.default.PropTypes.string,
+  culture: _propTypes2.default.string,
 
-  format: _propTypes2.default.dateFormat,
-  timeFormat: _propTypes2.default.dateFormat,
-  editFormat: _propTypes2.default.dateFormat,
+  format: _propTypes4.default.dateFormat,
+  timeFormat: _propTypes4.default.dateFormat,
+  editFormat: _propTypes4.default.dateFormat,
 
-  calendar: _react2.default.PropTypes.bool,
-  time: _react2.default.PropTypes.bool,
+  calendar: _propTypes2.default.bool,
+  time: _propTypes2.default.bool,
 
-  timeComponent: _propTypes2.default.elementType,
+  timeComponent: _propTypes4.default.elementType,
 
   //popup
-  dropUp: _react2.default.PropTypes.bool,
-  duration: _react2.default.PropTypes.number,
+  dropUp: _propTypes2.default.bool,
+  duration: _propTypes2.default.number,
 
-  placeholder: _react2.default.PropTypes.string,
-  name: _react2.default.PropTypes.string,
+  placeholder: _propTypes2.default.string,
+  name: _propTypes2.default.string,
 
-  initialView: _react2.default.PropTypes.oneOf(viewEnum),
-  finalView: _react2.default.PropTypes.oneOf(viewEnum),
+  initialView: _propTypes2.default.oneOf(viewEnum),
+  finalView: _propTypes2.default.oneOf(viewEnum),
 
-  autoFocus: _react2.default.PropTypes.bool,
-  disabled: _propTypes2.default.disabled,
-  readOnly: _propTypes2.default.readOnly,
+  autoFocus: _propTypes2.default.bool,
+  disabled: _propTypes4.default.disabled,
+  readOnly: _propTypes4.default.readOnly,
 
-  parse: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.arrayOf(_react2.default.PropTypes.string), _react2.default.PropTypes.string, _react2.default.PropTypes.func]),
+  parse: _propTypes2.default.oneOfType([_propTypes2.default.arrayOf(_propTypes2.default.string), _propTypes2.default.string, _propTypes2.default.func]),
 
-  'aria-labelledby': _react2.default.PropTypes.string,
+  'aria-labelledby': _propTypes2.default.string,
 
-  messages: _react2.default.PropTypes.shape({
-    calendarButton: _react2.default.PropTypes.string,
-    timeButton: _react2.default.PropTypes.string
+  messages: _propTypes2.default.shape({
+    calendarButton: _propTypes2.default.string,
+    timeButton: _propTypes2.default.string
   })
 });
 
-var DateTimePicker = _react2.default.createClass((_obj = {
+var DateTimePicker = (0, _createReactClass2.default)((_obj = {
 
   displayName: 'DateTimePicker',
 
@@ -227,7 +231,7 @@ var DateTimePicker = _react2.default.createClass((_obj = {
     var focused = this.state.focused;
 
 
-    return _react2.default.createElement(_DateTimePickerInput2.default, {
+    return React.createElement(_DateTimePickerInput2.default, {
       id: id,
       ref: 'valueInput',
       role: 'combobox',
@@ -264,17 +268,17 @@ var DateTimePicker = _react2.default.createClass((_obj = {
       return null;
     }
 
-    return _react2.default.createElement(
+    return React.createElement(
       'span',
       { className: 'rw-select' },
-      calendar && _react2.default.createElement(_Button2.default, {
+      calendar && React.createElement(_Button2.default, {
         icon: 'calendar',
         className: 'rw-btn-calendar',
         label: messages.calendarButton,
         disabled: !!(disabled || readOnly),
         onClick: this._click.bind(null, _constants.datePopups.CALENDAR)
       }),
-      time && _react2.default.createElement(_Button2.default, {
+      time && React.createElement(_Button2.default, {
         icon: 'clock-o',
         className: 'rw-btn-time',
         label: messages.timeButton,
@@ -295,7 +299,7 @@ var DateTimePicker = _react2.default.createClass((_obj = {
 
     var calendarProps = _3.default.pickProps(this.props, Calendar);
 
-    return _react2.default.createElement(
+    return React.createElement(
       _Popup2.default,
       {
         dropUp: dropUp,
@@ -303,7 +307,7 @@ var DateTimePicker = _react2.default.createClass((_obj = {
         open: open === _constants.datePopups.CALENDAR,
         className: 'rw-calendar-popup'
       },
-      _react2.default.createElement(Calendar, _extends({}, calendarProps, {
+      React.createElement(Calendar, _extends({}, calendarProps, {
         ref: 'calPopup',
         id: id,
         tabIndex: '-1',
@@ -339,7 +343,7 @@ var DateTimePicker = _react2.default.createClass((_obj = {
 
     var timeListProps = _3.default.pickProps(this.props, _TimeList2.default);
 
-    return _react2.default.createElement(
+    return React.createElement(
       _Popup2.default,
       {
         dropUp: dropUp,
@@ -349,10 +353,10 @@ var DateTimePicker = _react2.default.createClass((_obj = {
           return _this2.refs.timePopup.forceUpdate();
         }
       },
-      _react2.default.createElement(
+      React.createElement(
         'div',
         null,
-        _react2.default.createElement(_TimeList2.default, _extends({}, timeListProps, {
+        React.createElement(_TimeList2.default, _extends({}, timeListProps, {
           ref: 'timePopup',
           id: id,
           format: timeFormat,
@@ -394,7 +398,7 @@ var DateTimePicker = _react2.default.createClass((_obj = {
     if (calendar) owns += dateListID;
     if (time) owns += ' ' + timeListID;
 
-    return _react2.default.createElement(
+    return React.createElement(
       _Widget2.default,
       _extends({}, elementProps, {
         open: !!open,

--- a/lib/DateTimePickerInput.js
+++ b/lib/DateTimePickerInput.js
@@ -1,8 +1,15 @@
 'use strict';
 
 exports.__esModule = true;
+exports.default = undefined;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _class, _temp, _initialiseProps;
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _react = require('react');
 
@@ -22,28 +29,42 @@ var _compat2 = _interopRequireDefault(_compat);
 
 var _localizers = require('./util/localizers');
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-exports.default = _react2.default.createClass({
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-  displayName: 'DateTimePickerInput',
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-  propTypes: {
-    format: _propTypes2.default.dateFormat.isRequired,
-    editing: _react2.default.PropTypes.bool,
-    editFormat: _propTypes2.default.dateFormat,
-    parse: _react2.default.PropTypes.func.isRequired,
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-    value: _react2.default.PropTypes.instanceOf(Date),
-    onChange: _react2.default.PropTypes.func.isRequired,
-    culture: _react2.default.PropTypes.string
-  },
+var _default = (_temp = _class = function (_React$Component) {
+  _inherits(_default, _React$Component);
 
-  componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
+  function _default(props) {
+    _classCallCheck(this, _default);
+
+    var _this = _possibleConstructorReturn(this, _React$Component.call(this, props));
+
+    _initialiseProps.call(_this);
+
+    var value = props.value,
+        editing = props.editing,
+        editFormat = props.editFormat,
+        format = props.format,
+        culture = props.culture;
+
+
+    _this.state = {
+      textValue: formatDate(value, editing && editFormat ? editFormat : format, culture)
+    };
+    return _this;
+  }
+
+  _default.prototype.componentWillReceiveProps = function componentWillReceiveProps(nextProps) {
     var value = nextProps.value,
         editing = nextProps.editing,
         editFormat = nextProps.editFormat,
@@ -54,24 +75,12 @@ exports.default = _react2.default.createClass({
     this.setState({
       textValue: formatDate(value, editing && editFormat ? editFormat : format, culture)
     });
-  },
-  getInitialState: function getInitialState() {
+  };
+
+  _default.prototype.render = function render() {
     var _props = this.props,
-        value = _props.value,
-        editing = _props.editing,
-        editFormat = _props.editFormat,
-        format = _props.format,
-        culture = _props.culture;
-
-
-    return {
-      textValue: formatDate(value, editing && editFormat ? editFormat : format, culture)
-    };
-  },
-  render: function render() {
-    var _props2 = this.props,
-        disabled = _props2.disabled,
-        readOnly = _props2.readOnly;
+        disabled = _props.disabled,
+        readOnly = _props.readOnly;
     var textValue = this.state.textValue;
 
 
@@ -87,44 +96,63 @@ exports.default = _react2.default.createClass({
       onKeyDown: this.handleKeyDown,
       size: textValue.length
     }));
-  },
-  handleKeyDown: function handleKeyDown(event) {
+  };
+
+  return _default;
+}(_react2.default.Component), _class.displayName = 'DateTimePickerInput', _class.propTypes = {
+  format: _propTypes4.default.dateFormat.isRequired,
+  editing: _propTypes2.default.bool,
+  editFormat: _propTypes4.default.dateFormat,
+  parse: _propTypes2.default.func.isRequired,
+
+  value: _propTypes2.default.instanceOf(Date),
+  onChange: _propTypes2.default.func.isRequired,
+  culture: _propTypes2.default.string
+}, _initialiseProps = function _initialiseProps() {
+  var _this2 = this;
+
+  this.handleKeyDown = function (event) {
     if (event.key == 'Enter') {
-      var date = this.props.parse(event.target.value);
-      _compat2.default.findDOMNode(this).blur();
-      this.props.onChange(date, formatDate(date, this.props.format, this.props.culture));
+      var date = _this2.props.parse(event.target.value);
+      _compat2.default.findDOMNode(_this2).blur();
+      _this2.props.onChange(date, formatDate(date, _this2.props.format, _this2.props.culture));
     } else if (event.key == 'Escape') {
-      _compat2.default.findDOMNode(this).blur();
+      _compat2.default.findDOMNode(_this2).blur();
     }
-  },
-  handleChange: function handleChange(_ref) {
+  };
+
+  this.handleChange = function (_ref) {
     var value = _ref.target.value;
 
-    this._needsFlush = true;
-    this.setState({ textValue: value });
-  },
-  handleBlur: function handleBlur(event) {
-    var _props3 = this.props,
-        format = _props3.format,
-        culture = _props3.culture,
-        parse = _props3.parse,
-        onChange = _props3.onChange,
-        onBlur = _props3.onBlur;
+    _this2._needsFlush = true;
+    _this2.setState({ textValue: value });
+  };
+
+  this.handleBlur = function (event) {
+    var _props2 = _this2.props,
+        format = _props2.format,
+        culture = _props2.culture,
+        parse = _props2.parse,
+        onChange = _props2.onChange,
+        onBlur = _props2.onBlur;
 
 
     onBlur && onBlur(event);
 
-    if (this._needsFlush) {
+    if (_this2._needsFlush) {
       var date = parse(event.target.value);
 
-      this._needsFlush = false;
+      _this2._needsFlush = false;
       onChange(date, formatDate(date, format, culture));
     }
-  },
-  focus: function focus() {
-    _compat2.default.findDOMNode(this).focus();
-  }
-});
+  };
+
+  this.focus = function () {
+    _compat2.default.findDOMNode(_this2).focus();
+  };
+}, _temp);
+
+exports.default = _default;
 
 
 function isValid(d) {

--- a/lib/Decade.js
+++ b/lib/Decade.js
@@ -2,9 +2,17 @@
 
 exports.__esModule = true;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _CalendarView = require('./CalendarView');
 
@@ -20,31 +28,31 @@ var _2 = require('./util/_');
 
 var _3 = _interopRequireDefault(_2);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _widgetHelpers = require('./util/widgetHelpers');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var propTypes = {
-  culture: _react2.default.PropTypes.string,
-  today: _react2.default.PropTypes.instanceOf(Date),
-  value: _react2.default.PropTypes.instanceOf(Date),
-  focused: _react2.default.PropTypes.instanceOf(Date),
-  min: _react2.default.PropTypes.instanceOf(Date),
-  max: _react2.default.PropTypes.instanceOf(Date),
-  onChange: _react2.default.PropTypes.func.isRequired,
+  culture: _propTypes2.default.string,
+  today: _propTypes2.default.instanceOf(Date),
+  value: _propTypes2.default.instanceOf(Date),
+  focused: _propTypes2.default.instanceOf(Date),
+  min: _propTypes2.default.instanceOf(Date),
+  max: _propTypes2.default.instanceOf(Date),
+  onChange: _propTypes2.default.func.isRequired,
 
-  yearFormat: _propTypes2.default.dateFormat
+  yearFormat: _propTypes4.default.dateFormat
 };
 
 var optionId = function optionId(id, date) {
   return id + '__decade_' + _dates2.default.year(date);
 };
 
-exports.default = _react2.default.createClass({
+exports.default = (0, _createReactClass2.default)({
 
   displayName: 'DecadeView',
 

--- a/lib/DropdownList.js
+++ b/lib/DropdownList.js
@@ -6,9 +6,17 @@ var _desc, _value, _obj;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _activeElement = require('dom-helpers/activeElement');
 
@@ -50,9 +58,9 @@ var _compat = require('./util/compat');
 
 var _compat2 = _interopRequireDefault(_compat);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _List = require('./List');
 
@@ -113,43 +121,43 @@ var result = _3.default.result;
 var propTypes = _extends({}, _Popup2.default.propTypes, {
 
   //-- controlled props -----------
-  value: _react2.default.PropTypes.any,
-  onChange: _react2.default.PropTypes.func,
-  open: _react2.default.PropTypes.bool,
-  onToggle: _react2.default.PropTypes.func,
+  value: _propTypes2.default.any,
+  onChange: _propTypes2.default.func,
+  open: _propTypes2.default.bool,
+  onToggle: _propTypes2.default.func,
   //------------------------------------
 
-  data: _react2.default.PropTypes.array,
-  valueField: _react2.default.PropTypes.string,
-  textField: _propTypes2.default.accessor,
+  data: _propTypes2.default.array,
+  valueField: _propTypes2.default.string,
+  textField: _propTypes4.default.accessor,
 
-  valueComponent: _propTypes2.default.elementType,
-  itemComponent: _propTypes2.default.elementType,
-  listComponent: _propTypes2.default.elementType,
+  valueComponent: _propTypes4.default.elementType,
+  itemComponent: _propTypes4.default.elementType,
+  listComponent: _propTypes4.default.elementType,
 
-  groupComponent: _propTypes2.default.elementType,
-  groupBy: _propTypes2.default.accessor,
+  groupComponent: _propTypes4.default.elementType,
+  groupBy: _propTypes4.default.accessor,
 
-  onSelect: _react2.default.PropTypes.func,
-  searchTerm: _react2.default.PropTypes.string,
-  onSearch: _react2.default.PropTypes.func,
-  busy: _react2.default.PropTypes.bool,
-  delay: _react2.default.PropTypes.number,
-  dropUp: _react2.default.PropTypes.bool,
-  duration: _react2.default.PropTypes.number, //popup
+  onSelect: _propTypes2.default.func,
+  searchTerm: _propTypes2.default.string,
+  onSearch: _propTypes2.default.func,
+  busy: _propTypes2.default.bool,
+  delay: _propTypes2.default.number,
+  dropUp: _propTypes2.default.bool,
+  duration: _propTypes2.default.number, //popup
 
-  disabled: _propTypes2.default.disabled.acceptsArray,
-  readOnly: _propTypes2.default.readOnly.acceptsArray,
+  disabled: _propTypes4.default.disabled.acceptsArray,
+  readOnly: _propTypes4.default.readOnly.acceptsArray,
 
-  messages: _react2.default.PropTypes.shape({
-    open: _propTypes2.default.message,
-    emptyList: _propTypes2.default.message,
-    emptyFilter: _propTypes2.default.message,
-    filterPlaceholder: _propTypes2.default.message
+  messages: _propTypes2.default.shape({
+    open: _propTypes4.default.message,
+    emptyList: _propTypes4.default.message,
+    emptyFilter: _propTypes4.default.message,
+    filterPlaceholder: _propTypes4.default.message
   })
 });
 
-var DropdownList = _react2.default.createClass((_obj = {
+var DropdownList = (0, _createReactClass2.default)((_obj = {
 
   displayName: 'DropdownList',
 
@@ -362,122 +370,8 @@ var DropdownList = _react2.default.createClass((_obj = {
     (0, _widgetHelpers.notify)(this.props.onSelect, data);
     this.change(data);
     this.focus(this);
-  },
-  handleClick: function handleClick(e) {
-    var wrapper = this.refs.filterWrapper;
-
-    if (!this.props.filter || !this.props.open) this.toggle();else if (!(0, _contains2.default)(_compat2.default.findDOMNode(wrapper), e.target)) this.close();
-
-    (0, _widgetHelpers.notify)(this.props.onClick, e);
-  },
-  handleKeyDown: function handleKeyDown(e) {
-    var _this3 = this;
-
-    var key = e.key,
-        alt = e.altKey,
-        list = this.refs.list,
-        filtering = this.props.filter,
-        focusedItem = this.state.focusedItem,
-        selectedItem = this.state.selectedItem,
-        isOpen = this.props.open,
-        closeWithFocus = function closeWithFocus() {
-      _this3.close(), _compat2.default.findDOMNode(_this3).focus();
-    };
-
-    (0, _widgetHelpers.notify)(this.props.onKeyDown, [e]);
-
-    var change = function change(item, fromList) {
-      if (item == null) return;
-      fromList ? _this3.handleSelect(item) : _this3.change(item);
-    };
-
-    if (e.defaultPrevented) return;
-
-    if (key === 'End') {
-      e.preventDefault();
-
-      if (isOpen) this.setState({ focusedItem: list.last() });else change(list.last());
-    } else if (key === 'Home') {
-      e.preventDefault();
-
-      if (isOpen) this.setState({ focusedItem: list.first() });else change(list.first());
-    } else if (key === 'Escape' && isOpen) {
-      e.preventDefault();
-      closeWithFocus();
-    } else if ((key === 'Enter' || key === ' ' && !filtering) && isOpen) {
-      e.preventDefault();
-      change(this.state.focusedItem, true);
-    } else if (key === ' ' && !filtering && !isOpen) {
-      e.preventDefault();
-      this.open();
-    } else if (key === 'ArrowDown') {
-      if (alt) this.open();else if (isOpen) this.setState({ focusedItem: list.next(focusedItem) });else change(list.next(selectedItem));
-      e.preventDefault();
-    } else if (key === 'ArrowUp') {
-      if (alt) closeWithFocus();else if (isOpen) this.setState({ focusedItem: list.prev(focusedItem) });else change(list.prev(selectedItem));
-      e.preventDefault();
-    }
-  },
-  handleKeyPress: function handleKeyPress(e) {
-    var _this4 = this;
-
-    (0, _widgetHelpers.notify)(this.props.onKeyPress, [e]);
-
-    if (e.defaultPrevented) return;
-
-    if (!(this.props.filter && this.props.open)) this.search(String.fromCharCode(e.which), function (item) {
-      _this4.isMounted() && _this4.props.open ? _this4.setState({ focusedItem: item }) : item && _this4.change(item);
-    });
-  },
-  change: function change(data) {
-    if (!(0, _dataHelpers.valueMatcher)(data, this.props.value, this.props.valueField)) {
-      (0, _widgetHelpers.notify)(this.props.onChange, data);
-      (0, _widgetHelpers.notify)(this.props.onSearch, '');
-      this.close();
-    }
-  },
-  focus: function focus(target) {
-    var _props4 = this.props,
-        filter = _props4.filter,
-        open = _props4.open;
-
-    var inst = target || (filter && open ? this.refs.filter : this.refs.input);
-
-    inst = _compat2.default.findDOMNode(inst);
-
-    if ((0, _activeElement2.default)() !== inst) inst.focus();
-  },
-  _data: function _data() {
-    return this.state.filteredData || this.props.data.concat();
-  },
-  search: function search(character, cb) {
-    var _this5 = this;
-
-    var word = ((this._searchTerm || '') + character).toLowerCase();
-
-    if (!character) return;
-
-    this._searchTerm = word;
-
-    this.setTimeout('search', function () {
-      var list = _this5.refs.list,
-          key = _this5.props.open ? 'focusedItem' : 'selectedItem',
-          item = list.next(_this5.state[key], word);
-
-      _this5._searchTerm = '';
-      if (item) cb(item);
-    }, this.props.delay);
-  },
-  open: function open() {
-    (0, _widgetHelpers.notify)(this.props.onToggle, true);
-  },
-  close: function close() {
-    (0, _widgetHelpers.notify)(this.props.onToggle, false);
-  },
-  toggle: function toggle() {
-    this.props.open ? this.close() : this.open();
   }
-}, (_applyDecoratedDescriptor(_obj, 'handleSelect', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleSelect'), _obj), _applyDecoratedDescriptor(_obj, 'handleClick', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleClick'), _obj), _applyDecoratedDescriptor(_obj, 'handleKeyDown', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleKeyDown'), _obj), _applyDecoratedDescriptor(_obj, 'handleKeyPress', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleKeyPress'), _obj)), _obj));
+}, (_applyDecoratedDescriptor(_obj, 'handleSelect', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleSelect'), _obj)), _obj));
 
 function msgs(msgs) {
   return _extends({

--- a/lib/DropdownListInput.js
+++ b/lib/DropdownListInput.js
@@ -4,13 +4,17 @@ exports.__esModule = true;
 
 var _class, _temp;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _dataHelpers = require('./util/dataHelpers');
 
@@ -52,10 +56,10 @@ var DropdownListInput = (_temp = _class = function (_React$Component) {
 
   return DropdownListInput;
 }(_react2.default.Component), _class.propTypes = {
-  value: _react.PropTypes.any,
-  placeholder: _react.PropTypes.string,
-  textField: _propTypes2.default.accessor,
-  valueComponent: _propTypes2.default.elementType
+  value: _propTypes2.default.any,
+  placeholder: _propTypes2.default.string,
+  textField: _propTypes4.default.accessor,
+  valueComponent: _propTypes4.default.elementType
 }, _temp);
 exports.default = DropdownListInput;
 module.exports = exports['default'];

--- a/lib/Footer.js
+++ b/lib/Footer.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _class, _temp;
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -12,15 +14,26 @@ var _localizers = require('./util/localizers');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
 var format = function format(props) {
   return _localizers.date.getFormat('footer', props.format);
 };
 
-module.exports = _react2.default.createClass({
+module.exports = (_temp = _class = function (_React$Component) {
+  _inherits(_class, _React$Component);
 
-  displayName: 'Footer',
+  function _class() {
+    _classCallCheck(this, _class);
 
-  render: function render() {
+    return _possibleConstructorReturn(this, _React$Component.apply(this, arguments));
+  }
+
+  _class.prototype.render = function render() {
     var _props = this.props,
         disabled = _props.disabled,
         readOnly = _props.readOnly,
@@ -39,5 +52,7 @@ module.exports = _react2.default.createClass({
         _localizers.date.format(value, format(this.props), this.props.culture)
       )
     );
-  }
-});
+  };
+
+  return _class;
+}(_react2.default.Component), _class.displayName = 'Footer', _temp);

--- a/lib/Header.js
+++ b/lib/Header.js
@@ -2,9 +2,17 @@
 
 exports.__esModule = true;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _Button = require('./Button');
 
@@ -12,22 +20,22 @@ var _Button2 = _interopRequireDefault(_Button);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-exports.default = _react2.default.createClass({
+exports.default = (0, _createReactClass2.default)({
   displayName: 'Header',
   propTypes: {
-    label: _react2.default.PropTypes.string.isRequired,
-    labelId: _react2.default.PropTypes.string,
+    label: _propTypes2.default.string.isRequired,
+    labelId: _propTypes2.default.string,
 
-    upDisabled: _react2.default.PropTypes.bool.isRequired,
-    prevDisabled: _react2.default.PropTypes.bool.isRequired,
-    nextDisabled: _react2.default.PropTypes.bool.isRequired,
-    onViewChange: _react2.default.PropTypes.func.isRequired,
-    onMoveLeft: _react2.default.PropTypes.func.isRequired,
-    onMoveRight: _react2.default.PropTypes.func.isRequired,
+    upDisabled: _propTypes2.default.bool.isRequired,
+    prevDisabled: _propTypes2.default.bool.isRequired,
+    nextDisabled: _propTypes2.default.bool.isRequired,
+    onViewChange: _propTypes2.default.func.isRequired,
+    onMoveLeft: _propTypes2.default.func.isRequired,
+    onMoveRight: _propTypes2.default.func.isRequired,
 
-    messages: _react2.default.PropTypes.shape({
-      moveBack: _react2.default.PropTypes.string,
-      moveForward: _react2.default.PropTypes.string
+    messages: _propTypes2.default.shape({
+      moveBack: _propTypes2.default.string,
+      moveForward: _propTypes2.default.string
     })
   },
 

--- a/lib/List.js
+++ b/lib/List.js
@@ -4,17 +4,25 @@ exports.__esModule = true;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _ListOption = require('./ListOption');
 
 var _ListOption2 = _interopRequireDefault(_ListOption);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _compat = require('./util/compat');
 
@@ -40,30 +48,30 @@ var optionId = function optionId(id, idx) {
   return id + '__option__' + idx;
 };
 
-exports.default = _react2.default.createClass({
+exports.default = (0, _createReactClass2.default)({
 
   displayName: 'List',
 
   mixins: [require('./mixins/ListMovementMixin'), require('./mixins/AriaDescendantMixin')()],
 
   propTypes: {
-    data: _react2.default.PropTypes.array,
-    onSelect: _react2.default.PropTypes.func,
-    onMove: _react2.default.PropTypes.func,
+    data: _propTypes2.default.array,
+    onSelect: _propTypes2.default.func,
+    onMove: _propTypes2.default.func,
 
-    optionComponent: _propTypes2.default.elementType,
-    itemComponent: _propTypes2.default.elementType,
+    optionComponent: _propTypes4.default.elementType,
+    itemComponent: _propTypes4.default.elementType,
 
-    selected: _react2.default.PropTypes.any,
-    focused: _react2.default.PropTypes.any,
-    valueField: _propTypes2.default.accessor,
-    textField: _propTypes2.default.accessor,
+    selected: _propTypes2.default.any,
+    focused: _propTypes2.default.any,
+    valueField: _propTypes4.default.accessor,
+    textField: _propTypes4.default.accessor,
 
-    disabled: _propTypes2.default.disabled.acceptsArray,
-    readOnly: _propTypes2.default.readOnly.acceptsArray,
+    disabled: _propTypes4.default.disabled.acceptsArray,
+    readOnly: _propTypes4.default.readOnly.acceptsArray,
 
-    messages: _react2.default.PropTypes.shape({
-      emptyList: _propTypes2.default.message
+    messages: _propTypes2.default.shape({
+      emptyList: _propTypes4.default.message
     })
   },
 

--- a/lib/ListGroupable.js
+++ b/lib/ListGroupable.js
@@ -4,17 +4,25 @@ exports.__esModule = true;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _ListOption = require('./ListOption');
 
 var _ListOption2 = _interopRequireDefault(_ListOption);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _compat = require('./util/compat');
 
@@ -44,34 +52,34 @@ var optionId = function optionId(id, idx) {
   return id + '__option__' + idx;
 };
 
-exports.default = _react2.default.createClass({
+exports.default = (0, _createReactClass2.default)({
 
   displayName: 'List',
 
   mixins: [require('./mixins/ListMovementMixin'), require('./mixins/AriaDescendantMixin')()],
 
   propTypes: {
-    data: _react2.default.PropTypes.array,
-    onSelect: _react2.default.PropTypes.func,
-    onMove: _react2.default.PropTypes.func,
+    data: _propTypes2.default.array,
+    onSelect: _propTypes2.default.func,
+    onMove: _propTypes2.default.func,
 
-    optionComponent: _propTypes2.default.elementType,
-    itemComponent: _propTypes2.default.elementType,
-    groupComponent: _propTypes2.default.elementType,
+    optionComponent: _propTypes4.default.elementType,
+    itemComponent: _propTypes4.default.elementType,
+    groupComponent: _propTypes4.default.elementType,
 
-    selected: _react2.default.PropTypes.any,
-    focused: _react2.default.PropTypes.any,
+    selected: _propTypes2.default.any,
+    focused: _propTypes2.default.any,
 
-    valueField: _propTypes2.default.accessor,
-    textField: _propTypes2.default.accessor,
+    valueField: _propTypes4.default.accessor,
+    textField: _propTypes4.default.accessor,
 
-    disabled: _propTypes2.default.disabled.acceptsArray,
-    readOnly: _propTypes2.default.readOnly.acceptsArray,
+    disabled: _propTypes4.default.disabled.acceptsArray,
+    readOnly: _propTypes4.default.readOnly.acceptsArray,
 
-    groupBy: _propTypes2.default.accessor,
+    groupBy: _propTypes4.default.accessor,
 
-    messages: _react2.default.PropTypes.shape({
-      emptyList: _propTypes2.default.message
+    messages: _propTypes2.default.shape({
+      emptyList: _propTypes4.default.message
     })
   },
 

--- a/lib/ListOption.js
+++ b/lib/ListOption.js
@@ -4,6 +4,12 @@ exports.__esModule = true;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _class, _temp;
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -18,18 +24,22 @@ var _3 = _interopRequireDefault(_2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var ListOption = _react2.default.createClass({
-  displayName: 'ListOption',
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-  propTypes: {
-    dataItem: _react2.default.PropTypes.any,
-    focused: _react2.default.PropTypes.bool,
-    selected: _react2.default.PropTypes.bool,
-    disabled: _react2.default.PropTypes.bool,
-    readOnly: _react2.default.PropTypes.bool
-  },
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-  render: function render() {
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var ListOption = (_temp = _class = function (_React$Component) {
+  _inherits(ListOption, _React$Component);
+
+  function ListOption() {
+    _classCallCheck(this, ListOption);
+
+    return _possibleConstructorReturn(this, _React$Component.apply(this, arguments));
+  }
+
+  ListOption.prototype.render = function render() {
     var _props = this.props,
         className = _props.className,
         children = _props.children,
@@ -58,8 +68,15 @@ var ListOption = _react2.default.createClass({
       }, props),
       children
     );
-  }
-});
+  };
 
+  return ListOption;
+}(_react2.default.Component), _class.propTypes = {
+  dataItem: _propTypes2.default.any,
+  focused: _propTypes2.default.bool,
+  selected: _propTypes2.default.bool,
+  disabled: _propTypes2.default.bool,
+  readOnly: _propTypes2.default.bool
+}, _temp);
 exports.default = ListOption;
 module.exports = exports['default'];

--- a/lib/Month.js
+++ b/lib/Month.js
@@ -2,9 +2,17 @@
 
 exports.__esModule = true;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _CalendarView = require('./CalendarView');
 
@@ -16,9 +24,9 @@ var _dates2 = _interopRequireDefault(_dates);
 
 var _localizers = require('./util/localizers');
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _2 = require('./util/_');
 
@@ -40,24 +48,24 @@ var optionId = function optionId(id, date) {
 };
 
 var propTypes = {
-  culture: _react2.default.PropTypes.string,
-  today: _react2.default.PropTypes.instanceOf(Date),
-  value: _react2.default.PropTypes.instanceOf(Date),
-  focused: _react2.default.PropTypes.instanceOf(Date),
-  min: _react2.default.PropTypes.instanceOf(Date),
-  max: _react2.default.PropTypes.instanceOf(Date),
-  onChange: _react2.default.PropTypes.func.isRequired,
+  culture: _propTypes2.default.string,
+  today: _propTypes2.default.instanceOf(Date),
+  value: _propTypes2.default.instanceOf(Date),
+  focused: _propTypes2.default.instanceOf(Date),
+  min: _propTypes2.default.instanceOf(Date),
+  max: _propTypes2.default.instanceOf(Date),
+  onChange: _propTypes2.default.func.isRequired,
 
-  dayComponent: _propTypes2.default.elementType,
-  dayFormat: _propTypes2.default.dateFormat,
-  dateFormat: _propTypes2.default.dateFormat
+  dayComponent: _propTypes4.default.elementType,
+  dayFormat: _propTypes4.default.dateFormat,
+  dateFormat: _propTypes4.default.dateFormat
 };
 
 var isEqual = function isEqual(dateA, dateB) {
   return _dates2.default.eq(dateA, dateB, 'day');
 };
 
-var MonthView = _react2.default.createClass({
+var MonthView = (0, _createReactClass2.default)({
 
   displayName: 'MonthView',
 

--- a/lib/Multiselect.js
+++ b/lib/Multiselect.js
@@ -6,9 +6,17 @@ var _desc, _value, _obj;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _classnames = require('classnames');
 
@@ -38,9 +46,9 @@ var _MultiselectTagList = require('./MultiselectTagList');
 
 var _MultiselectTagList2 = _interopRequireDefault(_MultiselectTagList);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _List = require('./List');
 
@@ -104,53 +112,53 @@ var splat = _3.default.splat;
 
 var propTypes = _extends({}, _Popup2.default.propTypes, {
 
-  data: _react2.default.PropTypes.array,
+  data: _propTypes2.default.array,
   //-- controlled props --
-  value: _react2.default.PropTypes.array,
-  onChange: _react2.default.PropTypes.func,
+  value: _propTypes2.default.array,
+  onChange: _propTypes2.default.func,
 
-  searchTerm: _react2.default.PropTypes.string,
-  onSearch: _react2.default.PropTypes.func,
+  searchTerm: _propTypes2.default.string,
+  onSearch: _propTypes2.default.func,
 
-  open: _react2.default.PropTypes.bool,
-  onToggle: _react2.default.PropTypes.func,
+  open: _propTypes2.default.bool,
+  onToggle: _propTypes2.default.func,
   //-------------------------------------------
 
-  valueField: _react2.default.PropTypes.string,
-  textField: _propTypes2.default.accessor,
+  valueField: _propTypes2.default.string,
+  textField: _propTypes4.default.accessor,
 
-  tagComponent: _propTypes2.default.elementType,
-  itemComponent: _propTypes2.default.elementType,
-  listComponent: _propTypes2.default.elementType,
+  tagComponent: _propTypes4.default.elementType,
+  itemComponent: _propTypes4.default.elementType,
+  listComponent: _propTypes4.default.elementType,
 
-  groupComponent: _propTypes2.default.elementType,
-  groupBy: _propTypes2.default.accessor,
+  groupComponent: _propTypes4.default.elementType,
+  groupBy: _propTypes4.default.accessor,
 
-  createComponent: _propTypes2.default.elementType,
+  createComponent: _propTypes4.default.elementType,
 
-  onSelect: _react2.default.PropTypes.func,
-  onCreate: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.oneOf([false]), _react2.default.PropTypes.func]),
+  onSelect: _propTypes2.default.func,
+  onCreate: _propTypes2.default.oneOfType([_propTypes2.default.oneOf([false]), _propTypes2.default.func]),
 
-  inputSize: _react2.default.PropTypes.func,
+  inputSize: _propTypes2.default.func,
 
-  busy: _react2.default.PropTypes.bool,
-  dropUp: _react2.default.PropTypes.bool,
+  busy: _propTypes2.default.bool,
+  dropUp: _propTypes2.default.bool,
 
-  placeholder: _react2.default.PropTypes.string,
+  placeholder: _propTypes2.default.string,
 
-  autoFocus: _react2.default.PropTypes.bool,
-  disabled: _propTypes2.default.disabled.acceptsArray,
-  readOnly: _propTypes2.default.readOnly.acceptsArray,
+  autoFocus: _propTypes2.default.bool,
+  disabled: _propTypes4.default.disabled.acceptsArray,
+  readOnly: _propTypes4.default.readOnly.acceptsArray,
 
-  messages: _react2.default.PropTypes.shape({
-    open: _propTypes2.default.message,
-    emptyList: _propTypes2.default.message,
-    emptyFilter: _propTypes2.default.message,
-    createNew: _propTypes2.default.message
+  messages: _propTypes2.default.shape({
+    open: _propTypes4.default.message,
+    emptyList: _propTypes4.default.message,
+    emptyFilter: _propTypes4.default.message,
+    createNew: _propTypes4.default.message
   })
 });
 
-var Multiselect = _react2.default.createClass((_obj = {
+var Multiselect = (0, _createReactClass2.default)((_obj = {
 
   displayName: 'Multiselect',
 
@@ -482,129 +490,8 @@ var Multiselect = _react2.default.createClass((_obj = {
   },
   handleInputInteraction: function handleInputInteraction() {
     this.open();
-  },
-  handleSelect: function handleSelect(data) {
-    if (data === undefined) {
-      if (this.props.onCreate) this.handleCreate(this.props.searchTerm);
-
-      return;
-    }
-    (0, _widgetHelpers.notify)(this.props.onSelect, data);
-    this.change(this.state.dataItems.concat(data));
-
-    this.close();
-    this.focus();
-  },
-  handleCreate: function handleCreate(tag) {
-    if (tag.trim() === '') return;
-
-    (0, _widgetHelpers.notify)(this.props.onCreate, tag);
-    this.props.searchTerm && (0, _widgetHelpers.notify)(this.props.onSearch, ['']);
-
-    this.close();
-    this.focus();
-  },
-  handleKeyDown: function handleKeyDown(e) {
-    var key = e.key,
-        keyCode = e.keyCode,
-        altKey = e.altKey,
-        ctrlKey = e.ctrlKey,
-        noSearch = !this.props.searchTerm && !this._deletingText,
-        isOpen = this.props.open;
-    var _state4 = this.state,
-        focusedTag = _state4.focusedTag,
-        focusedItem = _state4.focusedItem;
-    var _refs = this.refs,
-        list = _refs.list,
-        tagList = _refs.tagList;
-
-    var nullTag = { focusedTag: null };
-
-    (0, _widgetHelpers.notify)(this.props.onKeyDown, [e]);
-
-    if (e.defaultPrevented) return;
-
-    if (key === 'ArrowDown') {
-      var next = list.next(focusedItem),
-          creating = this.shouldShowCreate() && focusedItem === next || focusedItem === null;
-
-      next = creating ? null : next;
-
-      e.preventDefault();
-      if (isOpen) this.setState(_extends({ focusedItem: next }, nullTag));else this.open();
-    } else if (key === 'ArrowUp') {
-      var prev = focusedItem === null ? list.last() : list.prev(focusedItem);
-
-      e.preventDefault();
-
-      if (altKey) this.close();else if (isOpen) this.setState(_extends({ focusedItem: prev }, nullTag));
-    } else if (key === 'End') {
-      e.preventDefault();
-      if (isOpen) this.setState(_extends({ focusedItem: list.last() }, nullTag));else tagList && this.setState({ focusedTag: tagList.last() });
-    } else if (key === 'Home') {
-      e.preventDefault();
-      if (isOpen) this.setState(_extends({ focusedItem: list.first() }, nullTag));else tagList && this.setState({ focusedTag: tagList.first() });
-    } else if (isOpen && keyCode === 13) {
-      // using keyCode to ignore enter for japanese IME
-      e.preventDefault();
-      ctrlKey && this.props.onCreate || focusedItem === null ? this.handleCreate(this.props.searchTerm) : this.handleSelect(this.state.focusedItem);
-    } else if (key === 'Escape') isOpen ? this.close() : tagList && this.setState(nullTag);else if (noSearch && key === 'ArrowLeft') tagList && this.setState({ focusedTag: tagList.prev(focusedTag) });else if (noSearch && key === 'ArrowRight') tagList && this.setState({ focusedTag: tagList.next(focusedTag) });else if (noSearch && key === 'Delete') tagList && tagList.remove(focusedTag);else if (noSearch && key === 'Backspace') tagList && tagList.removeNext();
-  },
-  change: function change(data) {
-    (0, _widgetHelpers.notify)(this.props.onChange, [data]);
-    (0, _widgetHelpers.notify)(this.props.onSearch, ['']);
-  },
-  focus: function focus() {
-    this.refs.input && this.refs.input.focus();
-  },
-  open: function open() {
-    if (!this.props.open) (0, _widgetHelpers.notify)(this.props.onToggle, true);
-  },
-  close: function close() {
-    (0, _widgetHelpers.notify)(this.props.onToggle, false);
-  },
-  toggle: function toggle() {
-    this.props.open ? this.close() : this.open();
-  },
-  process: function process(data, values, searchTerm) {
-    var valueField = this.props.valueField;
-
-    var items = data.filter(function (i) {
-      return !values.some(function (v) {
-        return (0, _dataHelpers.valueMatcher)(i, v, valueField);
-      });
-    });
-
-    this._lengthWithoutValues = items.length;
-
-    if (searchTerm) items = this.filter(items, searchTerm);
-
-    return items;
-  },
-  shouldShowCreate: function shouldShowCreate() {
-    var _props6 = this.props,
-        textField = _props6.textField,
-        searchTerm = _props6.searchTerm,
-        onCreate = _props6.onCreate,
-        caseSensitive = _props6.caseSensitive;
-
-
-    if (!onCreate || !searchTerm) return false;
-
-    var lower = function lower(text) {
-      return caseSensitive ? text : text.toLowerCase();
-    };
-    var eq = function eq(v) {
-      return lower((0, _dataHelpers.dataText)(v, textField)) === lower(searchTerm);
-    };
-
-    // if there is an exact match on textFields: "john" => { name: "john" }, don't show
-    return !this._data().some(eq) && !this.state.dataItems.some(eq);
-  },
-  getPlaceholder: function getPlaceholder() {
-    return (this.props.value || []).length ? '' : this.props.placeholder || '';
   }
-}, (_applyDecoratedDescriptor(_obj, 'handleInputInteraction', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleInputInteraction'), _obj), _applyDecoratedDescriptor(_obj, 'handleSelect', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleSelect'), _obj), _applyDecoratedDescriptor(_obj, 'handleCreate', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleCreate'), _obj), _applyDecoratedDescriptor(_obj, 'handleKeyDown', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleKeyDown'), _obj), _applyDecoratedDescriptor(_obj, 'change', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'change'), _obj)), _obj));
+}, (_applyDecoratedDescriptor(_obj, 'handleInputInteraction', [_interaction.widgetEditable], Object.getOwnPropertyDescriptor(_obj, 'handleInputInteraction'), _obj)), _obj));
 
 function msgs(msgs) {
   return _extends({

--- a/lib/MultiselectInput.js
+++ b/lib/MultiselectInput.js
@@ -6,6 +6,10 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 var _class, _temp;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -18,9 +22,9 @@ var _compat = require('./util/compat');
 
 var _compat2 = _interopRequireDefault(_compat);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -68,14 +72,14 @@ var MultiselectInput = (_temp = _class = function (_React$Component) {
 
   return MultiselectInput;
 }(_react2.default.Component), _class.propTypes = {
-  value: _react2.default.PropTypes.string,
-  placeholder: _react2.default.PropTypes.string,
-  maxLength: _react2.default.PropTypes.number,
-  inputSize: _react2.default.PropTypes.func,
-  onChange: _react2.default.PropTypes.func.isRequired,
+  value: _propTypes2.default.string,
+  placeholder: _propTypes2.default.string,
+  maxLength: _propTypes2.default.number,
+  inputSize: _propTypes2.default.func,
+  onChange: _propTypes2.default.func.isRequired,
 
-  disabled: _propTypes2.default.disabled,
-  readOnly: _propTypes2.default.readOnly
+  disabled: _propTypes4.default.disabled,
+  readOnly: _propTypes4.default.readOnly
 }, _temp);
 exports.default = MultiselectInput;
 module.exports = exports['default'];

--- a/lib/MultiselectTagList.js
+++ b/lib/MultiselectTagList.js
@@ -4,9 +4,17 @@ exports.__esModule = true;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _2 = require('./util/_');
 
@@ -16,9 +24,9 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _widgetHelpers = require('./util/widgetHelpers');
 
@@ -32,24 +40,23 @@ var optionId = function optionId(id, idx) {
   return id + '__option__' + idx;
 };
 
-exports.default = _react2.default.createClass({
+exports.default = (0, _createReactClass2.default)({
   displayName: 'MultiselectTagList',
-
 
   mixins: [require('./mixins/PureRenderMixin'), require('./mixins/AriaDescendantMixin')()],
 
   propTypes: {
-    value: _react2.default.PropTypes.array,
-    focused: _react2.default.PropTypes.number,
+    value: _propTypes2.default.array,
+    focused: _propTypes2.default.number,
 
-    valueField: _react2.default.PropTypes.string,
-    textField: _propTypes2.default.accessor,
+    valueField: _propTypes2.default.string,
+    textField: _propTypes4.default.accessor,
 
-    onDelete: _react2.default.PropTypes.func.isRequired,
-    valueComponent: _react2.default.PropTypes.func,
+    onDelete: _propTypes2.default.func.isRequired,
+    valueComponent: _propTypes2.default.func,
 
-    disabled: _propTypes2.default.disabled.acceptsArray,
-    readOnly: _propTypes2.default.readOnly.acceptsArray
+    disabled: _propTypes4.default.disabled.acceptsArray,
+    readOnly: _propTypes4.default.readOnly.acceptsArray
   },
 
   getDefaultProps: function getDefaultProps() {

--- a/lib/NumberInput.js
+++ b/lib/NumberInput.js
@@ -1,8 +1,15 @@
 'use strict';
 
 exports.__esModule = true;
+exports.default = undefined;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _class, _temp2;
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _react = require('react');
 
@@ -12,66 +19,142 @@ var _2 = require('./util/_');
 
 var _3 = _interopRequireDefault(_2);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _localizers = require('./util/localizers');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var getFormat = function getFormat(props) {
   return _localizers.number.getFormat('default', props.format);
 };
 
 var propTypes = {
-  value: _react2.default.PropTypes.number,
-  editing: _react2.default.PropTypes.bool,
-  placeholder: _react2.default.PropTypes.string,
+  value: _propTypes2.default.number,
+  editing: _propTypes2.default.bool,
+  placeholder: _propTypes2.default.string,
 
-  format: _propTypes2.default.numberFormat,
+  format: _propTypes4.default.numberFormat,
 
-  parse: _react2.default.PropTypes.func,
-  culture: _react2.default.PropTypes.string,
+  parse: _propTypes2.default.func,
+  culture: _propTypes2.default.string,
 
-  min: _react2.default.PropTypes.number,
+  min: _propTypes2.default.number,
 
-  onChange: _react2.default.PropTypes.func.isRequired,
-  onKeyDown: _react2.default.PropTypes.func
+  onChange: _propTypes2.default.func.isRequired,
+  onKeyDown: _propTypes2.default.func
 };
 
-exports.default = _react2.default.createClass({
+var _default = (_temp2 = _class = function (_React$Component) {
+  _inherits(_default, _React$Component);
 
-  displayName: 'NumberPickerInput',
+  function _default() {
+    var _temp, _this, _ret;
 
-  propTypes: propTypes,
+    _classCallCheck(this, _default);
 
-  getDefaultProps: function getDefaultProps() {
-    return {
-      value: null,
-      editing: false
-    };
-  },
-  getDefaultState: function getDefaultState() {
-    var props = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this.props;
+    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
 
-    var value = props.value,
-        decimal = _localizers.number.decimalChar(null, props.culture),
-        format = getFormat(props);
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, _React$Component.call.apply(_React$Component, [this].concat(args))), _this), _this.getDefaultState = function () {
+      var props = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _this.props;
 
-    if (value == null || isNaN(props.value)) value = '';else value = props.editing ? ('' + value).replace('.', decimal) : _localizers.number.format(value, format, props.culture);
+      var value = props.value,
+          decimal = _localizers.number.decimalChar(null, props.culture),
+          format = getFormat(props);
 
-    return {
-      stringValue: '' + value
-    };
-  },
-  getInitialState: function getInitialState() {
-    return this.getDefaultState();
-  },
-  componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
+      if (value == null || isNaN(props.value)) value = '';else value = props.editing ? ('' + value).replace('.', decimal) : _localizers.number.format(value, format, props.culture);
+
+      return {
+        stringValue: '' + value
+      };
+    }, _this._change = function (e) {
+      var val = e.target.value,
+          number = _this._parse(e.target.value);
+
+      var isIntermediate = _this.isIntermediateValue(number, val);
+
+      if (val == null || val.trim() === '') {
+        _this.current('');
+        return _this.props.onChange(null);
+      }
+
+      if (!isIntermediate) {
+        if (number !== _this.props.value) {
+          return _this.props.onChange(number);
+        }
+      } else {
+        _this.current(e.target.value);
+      }
+    }, _this._finish = function () {
+      var str = _this.state.stringValue,
+          number = _this._parse(str);
+
+      // if number is below the min
+      // we need to flush low values and decimal stops, onBlur means i'm done inputing
+      if (_this.isIntermediateValue(number, str)) {
+        if (isNaN(number)) {
+          number = null;
+        }
+        _this.props.onChange(number);
+      }
+    }, _this._parse = function (strVal) {
+      var culture = _this.props.culture,
+          delimChar = _localizers.number.decimalChar(null, culture),
+          userParse = _this.props.parse;
+
+      if (userParse) return userParse(strVal, culture);
+
+      strVal = strVal.replace(delimChar, '.');
+      strVal = parseFloat(strVal);
+
+      return strVal;
+    }, _this.isIntermediateValue = function (num, str) {
+      return !!(num < _this.props.min || _this.isSign(str) || _this.isAtDelimiter(num, str) || _this.isPaddedZeros(str));
+    }, _this.isSign = function (val) {
+      return (val || '').trim() === '-';
+    }, _this.isPaddedZeros = function (str) {
+      var localeChar = _localizers.number.decimalChar(null, _this.props.culture);
+
+      var _str$split = str.split(localeChar),
+          _ = _str$split[0],
+          decimals = _str$split[1];
+
+      return !!(decimals && decimals.match(/0+$/));
+    }, _this.isAtDelimiter = function (num, str) {
+      var props = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : _this.props;
+
+      var localeChar = _localizers.number.decimalChar(null, props.culture),
+          lastIndex = str.length - 1,
+          char;
+
+      if (str.length < 1) return false;
+
+      char = str[lastIndex];
+
+      return !!(char === localeChar && str.indexOf(char) === lastIndex);
+    }, _this.isValid = function (num) {
+      if (typeof num !== 'number' || isNaN(num)) return false;
+      return num >= _this.props.min;
+    }, _this.current = function (stringValue) {
+      _this.setState({ stringValue: stringValue });
+    }, _this.state = _this.getDefaultState(), _temp), _possibleConstructorReturn(_this, _ret);
+  }
+
+  _default.prototype.componentWillReceiveProps = function componentWillReceiveProps(nextProps) {
     this.setState(this.getDefaultState(nextProps));
-  },
-  render: function render() {
+  };
+
+  _default.prototype.render = function render() {
     var value = this.state.stringValue;
     var props = _3.default.omitOwnProps(this);
 
@@ -87,88 +170,16 @@ exports.default = _react2.default.createClass({
       placeholder: this.props.placeholder,
       value: value
     }));
-  },
-  _change: function _change(e) {
-    var val = e.target.value,
-        number = this._parse(e.target.value);
-
-    var isIntermediate = this.isIntermediateValue(number, val);
-
-    if (val == null || val.trim() === '') {
-      this.current('');
-      return this.props.onChange(null);
-    }
-
-    if (!isIntermediate) {
-      if (number !== this.props.value) {
-        return this.props.onChange(number);
-      }
-    } else {
-      this.current(e.target.value);
-    }
-  },
-  _finish: function _finish() {
-    var str = this.state.stringValue,
-        number = this._parse(str);
-
-    // if number is below the min
-    // we need to flush low values and decimal stops, onBlur means i'm done inputing
-    if (this.isIntermediateValue(number, str)) {
-      if (isNaN(number)) {
-        number = null;
-      }
-      this.props.onChange(number);
-    }
-  },
-  _parse: function _parse(strVal) {
-    var culture = this.props.culture,
-        delimChar = _localizers.number.decimalChar(null, culture),
-        userParse = this.props.parse;
-
-    if (userParse) return userParse(strVal, culture);
-
-    strVal = strVal.replace(delimChar, '.');
-    strVal = parseFloat(strVal);
-
-    return strVal;
-  },
-  isIntermediateValue: function isIntermediateValue(num, str) {
-    return !!(num < this.props.min || this.isSign(str) || this.isAtDelimiter(num, str) || this.isPaddedZeros(str));
-  },
-  isSign: function isSign(val) {
-    return (val || '').trim() === '-';
-  },
-  isPaddedZeros: function isPaddedZeros(str) {
-    var localeChar = _localizers.number.decimalChar(null, this.props.culture);
-
-    var _str$split = str.split(localeChar),
-        _ = _str$split[0],
-        decimals = _str$split[1];
-
-    return !!(decimals && decimals.match(/0+$/));
-  },
-  isAtDelimiter: function isAtDelimiter(num, str) {
-    var props = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : this.props;
-
-    var localeChar = _localizers.number.decimalChar(null, props.culture),
-        lastIndex = str.length - 1,
-        char;
-
-    if (str.length < 1) return false;
-
-    char = str[lastIndex];
-
-    return !!(char === localeChar && str.indexOf(char) === lastIndex);
-  },
-  isValid: function isValid(num) {
-    if (typeof num !== 'number' || isNaN(num)) return false;
-    return num >= this.props.min;
-  },
-
+  };
 
   //this intermediate state is for when one runs into the decimal or are typing the number
-  current: function current(stringValue) {
-    this.setState({ stringValue: stringValue });
-  }
-});
+
+
+  return _default;
+}(_react2.default.Component), _class.displayName = 'NumberPickerInput', _class.propTypes = propTypes, _class.defaultProps = {
+  value: null,
+  editing: false
+}, _temp2);
+
+exports.default = _default;
 module.exports = exports['default'];

--- a/lib/NumberPicker.js
+++ b/lib/NumberPicker.js
@@ -6,9 +6,17 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 var _desc, _value, _obj;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _classnames = require('classnames');
 
@@ -22,9 +30,9 @@ var _compat = require('./util/compat');
 
 var _compat2 = _interopRequireDefault(_compat);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _uncontrollable = require('uncontrollable');
 
@@ -90,37 +98,37 @@ var format = function format(props) {
 var propTypes = {
 
   // -- controlled props -----------
-  value: _react2.default.PropTypes.number,
-  onChange: _react2.default.PropTypes.func,
+  value: _propTypes2.default.number,
+  onChange: _propTypes2.default.func,
   //------------------------------------
 
-  min: _react2.default.PropTypes.number,
-  max: _react2.default.PropTypes.number,
-  step: _react2.default.PropTypes.number,
+  min: _propTypes2.default.number,
+  max: _propTypes2.default.number,
+  step: _propTypes2.default.number,
 
-  precision: _react2.default.PropTypes.number,
+  precision: _propTypes2.default.number,
 
-  culture: _react2.default.PropTypes.string,
+  culture: _propTypes2.default.string,
 
-  format: _propTypes2.default.numberFormat,
+  format: _propTypes4.default.numberFormat,
 
-  name: _react2.default.PropTypes.string,
+  name: _propTypes2.default.string,
 
-  parse: _react2.default.PropTypes.func,
+  parse: _propTypes2.default.func,
 
-  autoFocus: _react2.default.PropTypes.bool,
-  disabled: _propTypes2.default.disabled,
-  readOnly: _propTypes2.default.readOnly,
+  autoFocus: _propTypes2.default.bool,
+  disabled: _propTypes4.default.disabled,
+  readOnly: _propTypes4.default.readOnly,
 
-  messages: _react2.default.PropTypes.shape({
-    increment: _react2.default.PropTypes.string,
-    decrement: _react2.default.PropTypes.string
+  messages: _propTypes2.default.shape({
+    increment: _propTypes2.default.string,
+    decrement: _propTypes2.default.string
   }),
 
-  placeholder: _react2.default.PropTypes.string
+  placeholder: _propTypes2.default.string
 };
 
-var NumberPicker = _react2.default.createClass((_obj = {
+var NumberPicker = (0, _createReactClass2.default)((_obj = {
 
   displayName: 'NumberPicker',
 

--- a/lib/Popup.js
+++ b/lib/Popup.js
@@ -1,10 +1,15 @@
 'use strict';
 
 exports.__esModule = true;
+exports.default = undefined;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _OVERFLOW;
+var _OVERFLOW, _class, _temp2;
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _react = require('react');
 
@@ -40,6 +45,12 @@ var _compat2 = _interopRequireDefault(_compat);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
 var transform = (0, _camelizeStyle2.default)(_configuration2.default.animate.transform);
 
 var CLOSING = 0,
@@ -60,56 +71,150 @@ function properties(prop, value) {
 var OVERFLOW = (_OVERFLOW = {}, _OVERFLOW[CLOSED] = 'hidden', _OVERFLOW[CLOSING] = 'hidden', _OVERFLOW[OPENING] = 'hidden', _OVERFLOW);
 
 var propTypes = {
-  open: _react2.default.PropTypes.bool,
-  dropUp: _react2.default.PropTypes.bool,
-  duration: _react2.default.PropTypes.number,
+  open: _propTypes2.default.bool,
+  dropUp: _propTypes2.default.bool,
+  duration: _propTypes2.default.number,
 
-  onClosing: _react2.default.PropTypes.func,
-  onOpening: _react2.default.PropTypes.func,
-  onClose: _react2.default.PropTypes.func,
-  onOpen: _react2.default.PropTypes.func
+  onClosing: _propTypes2.default.func,
+  onOpening: _propTypes2.default.func,
+  onClose: _propTypes2.default.func,
+  onOpen: _propTypes2.default.func
 };
 
-exports.default = _react2.default.createClass({
+var _default = (_temp2 = _class = function (_React$Component) {
+  _inherits(_default, _React$Component);
 
-  displayName: 'Popup',
+  function _default() {
+    var _temp, _this, _ret;
 
-  propTypes: propTypes,
+    _classCallCheck(this, _default);
 
-  getInitialState: function getInitialState() {
-    return {
+    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, _React$Component.call.apply(_React$Component, [this].concat(args))), _this), _this.state = {
       initialRender: true,
-      status: this.props.open ? OPENING : CLOSED
-    };
-  },
-  getDefaultProps: function getDefaultProps() {
-    return {
-      duration: 200,
-      open: false,
-      onClosing: function onClosing() {},
-      onOpening: function onOpening() {},
-      onClose: function onClose() {},
-      onOpen: function onOpen() {}
-    };
-  },
-  componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
+      status: _this.props.open ? OPENING : CLOSED
+    }, _this.renderChildren = function () {
+      if (!_this.props.children) return _react2.default.createElement('span', { className: 'rw-popup rw-widget' });
+
+      var offset = _this.getOffsetForStatus(_this.state.status),
+          child = _react2.default.Children.only(_this.props.children);
+
+      return (0, _react.cloneElement)(child, {
+        style: _extends({}, child.props.style, offset, {
+          position: _this.isTransitioning() ? 'absolute' : undefined
+        }),
+        className: (0, _classnames2.default)(child.props.className, 'rw-popup rw-widget')
+      });
+    }, _this.open = function () {
+      _this.cancelNextCallback();
+      var el = _compat2.default.findDOMNode(_this).firstChild,
+          height = _this.height();
+
+      _this.props.onOpening();
+
+      _this.safeSetState({ status: OPENING, height: height }, function () {
+        var offset = _this.getOffsetForStatus(OPEN),
+            duration = _this.props.duration;
+
+        _this.animate(el, offset, duration, 'ease', function () {
+          _this.safeSetState({ status: OPEN }, function () {
+            _this.props.onOpen();
+          });
+        });
+      });
+    }, _this.close = function () {
+      _this.cancelNextCallback();
+      var el = _compat2.default.findDOMNode(_this).firstChild,
+          height = _this.height();
+
+      _this.props.onClosing();
+
+      _this.safeSetState({ status: CLOSING, height: height }, function () {
+        var offset = _this.getOffsetForStatus(CLOSED),
+            duration = _this.props.duration;
+
+        _this.animate(el, offset, duration, 'ease', function () {
+          return _this.safeSetState({ status: CLOSED }, function () {
+            _this.props.onClose();
+          });
+        });
+      });
+    }, _this.getOffsetForStatus = function (status) {
+      var _CLOSED$CLOSING$OPENI;
+
+      if (_this.state.initialRender) return {};
+
+      var _in = properties('top', _this.props.dropUp ? '100%' : '-100%'),
+          out = properties('top', 0);
+      return (_CLOSED$CLOSING$OPENI = {}, _CLOSED$CLOSING$OPENI[CLOSED] = _in, _CLOSED$CLOSING$OPENI[CLOSING] = out, _CLOSED$CLOSING$OPENI[OPENING] = _in, _CLOSED$CLOSING$OPENI[OPEN] = out, _CLOSED$CLOSING$OPENI)[status] || {};
+    }, _this.height = function () {
+      var container = _compat2.default.findDOMNode(_this),
+          content = container.firstChild,
+          margin = parseInt((0, _style2.default)(content, 'margin-top'), 10) + parseInt((0, _style2.default)(content, 'margin-bottom'), 10);
+
+      var old = container.style.display,
+          height = void 0;
+
+      container.style.display = 'block';
+      height = ((0, _height2.default)(content) || 0) + (isNaN(margin) ? 0 : margin);
+      container.style.display = old;
+      return height;
+    }, _this.isTransitioning = function () {
+      return _this.state.status === OPENING || _this.state.status === CLOSED;
+    }, _this.animate = function (el, props, dur, easing, cb) {
+      _this._transition = _configuration2.default.animate(el, props, dur, easing, _this.setNextCallback(cb));
+    }, _this.cancelNextCallback = function () {
+      if (_this._transition && _this._transition.cancel) {
+        _this._transition.cancel();
+        _this._transition = null;
+      }
+      if (_this.nextCallback) {
+        _this.nextCallback.cancel();
+        _this.nextCallback = null;
+      }
+    }, _this.safeSetState = function (nextState, callback) {
+      _this.setState(nextState, _this.setNextCallback(callback));
+    }, _this.setNextCallback = function (callback) {
+      var active = true;
+
+      _this.nextCallback = function (event) {
+        if (active) {
+          active = false;
+          _this.nextCallback = null;
+          callback(event);
+        }
+      };
+
+      _this.nextCallback.cancel = function () {
+        return active = false;
+      };
+      return _this.nextCallback;
+    }, _temp), _possibleConstructorReturn(_this, _ret);
+  }
+
+  _default.prototype.componentWillReceiveProps = function componentWillReceiveProps(nextProps) {
     this.setState({
       contentChanged: childKey(nextProps.children) !== childKey(this.props.children)
     });
-  },
-  componentDidMount: function componentDidMount() {
-    var _this = this;
+  };
+
+  _default.prototype.componentDidMount = function componentDidMount() {
+    var _this2 = this;
 
     var isOpen = this.state.status === OPENING;
 
     _compat2.default.batchedUpdates(function () {
-      _this.setState({ initialRender: false });
+      _this2.setState({ initialRender: false });
       if (isOpen) {
-        _this.open();
+        _this2.open();
       }
     });
-  },
-  componentDidUpdate: function componentDidUpdate(pvProps) {
+  };
+
+  _default.prototype.componentDidUpdate = function componentDidUpdate(pvProps) {
     var closing = pvProps.open && !this.props.open,
         opening = !pvProps.open && this.props.open,
         open = this.props.open,
@@ -132,8 +237,9 @@ exports.default = _react2.default.createClass({
           diff = Math.abs(height - this.state.height);
       if (isNaN(diff) || diff > 0.1) this.setState({ height: height });
     }
-  },
-  render: function render() {
+  };
+
+  _default.prototype.render = function render() {
     var _props = this.props,
         className = _props.className,
         dropUp = _props.dropUp,
@@ -158,120 +264,19 @@ exports.default = _react2.default.createClass({
       },
       this.renderChildren()
     );
-  },
-  renderChildren: function renderChildren() {
-    if (!this.props.children) return _react2.default.createElement('span', { className: 'rw-popup rw-widget' });
+  };
 
-    var offset = this.getOffsetForStatus(this.state.status),
-        child = _react2.default.Children.only(this.props.children);
+  return _default;
+}(_react2.default.Component), _class.displayName = 'Popup', _class.propTypes = propTypes, _class.defaultProps = {
+  duration: 200,
+  open: false,
+  onClosing: function onClosing() {},
+  onOpening: function onOpening() {},
+  onClose: function onClose() {},
+  onOpen: function onOpen() {}
+}, _temp2);
 
-    return (0, _react.cloneElement)(child, {
-      style: _extends({}, child.props.style, offset, {
-        position: this.isTransitioning() ? 'absolute' : undefined
-      }),
-      className: (0, _classnames2.default)(child.props.className, 'rw-popup rw-widget')
-    });
-  },
-  open: function open() {
-    var _this2 = this;
-
-    this.cancelNextCallback();
-    var el = _compat2.default.findDOMNode(this).firstChild,
-        height = this.height();
-
-    this.props.onOpening();
-
-    this.safeSetState({ status: OPENING, height: height }, function () {
-      var offset = _this2.getOffsetForStatus(OPEN),
-          duration = _this2.props.duration;
-
-      _this2.animate(el, offset, duration, 'ease', function () {
-        _this2.safeSetState({ status: OPEN }, function () {
-          _this2.props.onOpen();
-        });
-      });
-    });
-  },
-  close: function close() {
-    var _this3 = this;
-
-    this.cancelNextCallback();
-    var el = _compat2.default.findDOMNode(this).firstChild,
-        height = this.height();
-
-    this.props.onClosing();
-
-    this.safeSetState({ status: CLOSING, height: height }, function () {
-      var offset = _this3.getOffsetForStatus(CLOSED),
-          duration = _this3.props.duration;
-
-      _this3.animate(el, offset, duration, 'ease', function () {
-        return _this3.safeSetState({ status: CLOSED }, function () {
-          _this3.props.onClose();
-        });
-      });
-    });
-  },
-  getOffsetForStatus: function getOffsetForStatus(status) {
-    var _CLOSED$CLOSING$OPENI;
-
-    if (this.state.initialRender) return {};
-
-    var _in = properties('top', this.props.dropUp ? '100%' : '-100%'),
-        out = properties('top', 0);
-    return (_CLOSED$CLOSING$OPENI = {}, _CLOSED$CLOSING$OPENI[CLOSED] = _in, _CLOSED$CLOSING$OPENI[CLOSING] = out, _CLOSED$CLOSING$OPENI[OPENING] = _in, _CLOSED$CLOSING$OPENI[OPEN] = out, _CLOSED$CLOSING$OPENI)[status] || {};
-  },
-  height: function height() {
-    var container = _compat2.default.findDOMNode(this),
-        content = container.firstChild,
-        margin = parseInt((0, _style2.default)(content, 'margin-top'), 10) + parseInt((0, _style2.default)(content, 'margin-bottom'), 10);
-
-    var old = container.style.display,
-        height = void 0;
-
-    container.style.display = 'block';
-    height = ((0, _height2.default)(content) || 0) + (isNaN(margin) ? 0 : margin);
-    container.style.display = old;
-    return height;
-  },
-  isTransitioning: function isTransitioning() {
-    return this.state.status === OPENING || this.state.status === CLOSED;
-  },
-  animate: function animate(el, props, dur, easing, cb) {
-    this._transition = _configuration2.default.animate(el, props, dur, easing, this.setNextCallback(cb));
-  },
-  cancelNextCallback: function cancelNextCallback() {
-    if (this._transition && this._transition.cancel) {
-      this._transition.cancel();
-      this._transition = null;
-    }
-    if (this.nextCallback) {
-      this.nextCallback.cancel();
-      this.nextCallback = null;
-    }
-  },
-  safeSetState: function safeSetState(nextState, callback) {
-    this.setState(nextState, this.setNextCallback(callback));
-  },
-  setNextCallback: function setNextCallback(callback) {
-    var _this4 = this;
-
-    var active = true;
-
-    this.nextCallback = function (event) {
-      if (active) {
-        active = false;
-        _this4.nextCallback = null;
-        callback(event);
-      }
-    };
-
-    this.nextCallback.cancel = function () {
-      return active = false;
-    };
-    return this.nextCallback;
-  }
-});
+exports.default = _default;
 
 
 function childKey(children) {

--- a/lib/ReplaceTransitionGroup.js
+++ b/lib/ReplaceTransitionGroup.js
@@ -2,9 +2,17 @@
 
 exports.__esModule = true;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _style = require('dom-helpers/style');
 
@@ -42,15 +50,15 @@ function key(child) {
   return child && child.key;
 }
 
-exports.default = _react2.default.createClass({
+exports.default = (0, _createReactClass2.default)({
 
   displayName: 'ReplaceTransitionGroup',
 
   propTypes: {
-    component: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.element, _react2.default.PropTypes.string]),
-    childFactory: _react2.default.PropTypes.func,
-    onAnimating: _react2.default.PropTypes.func,
-    onAnimate: _react2.default.PropTypes.func
+    component: _propTypes2.default.oneOfType([_propTypes2.default.element, _propTypes2.default.string]),
+    childFactory: _propTypes2.default.func,
+    onAnimating: _propTypes2.default.func,
+    onAnimate: _propTypes2.default.func
   },
 
   getDefaultProps: function getDefaultProps() {

--- a/lib/SelectList.js
+++ b/lib/SelectList.js
@@ -6,9 +6,17 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 var _desc, _value, _obj;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _2 = require('./util/_');
 
@@ -26,9 +34,9 @@ var _compat = require('./util/compat');
 
 var _compat2 = _interopRequireDefault(_compat);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _List = require('./List');
 
@@ -96,29 +104,29 @@ var find = _3.default.find;
 
 var propTypes = {
 
-  data: _react2.default.PropTypes.array,
-  value: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.any, _react2.default.PropTypes.array]),
-  onChange: _react2.default.PropTypes.func,
-  onMove: _react2.default.PropTypes.func,
+  data: _propTypes2.default.array,
+  value: _propTypes2.default.oneOfType([_propTypes2.default.any, _propTypes2.default.array]),
+  onChange: _propTypes2.default.func,
+  onMove: _propTypes2.default.func,
 
-  multiple: _react2.default.PropTypes.bool,
+  multiple: _propTypes2.default.bool,
 
-  itemComponent: _propTypes2.default.elementType,
-  listComponent: _propTypes2.default.elementType,
+  itemComponent: _propTypes4.default.elementType,
+  listComponent: _propTypes4.default.elementType,
 
-  valueField: _react2.default.PropTypes.string,
-  textField: _propTypes2.default.accessor,
+  valueField: _propTypes2.default.string,
+  textField: _propTypes4.default.accessor,
 
-  busy: _react2.default.PropTypes.bool,
+  busy: _propTypes2.default.bool,
 
-  filter: _react2.default.PropTypes.string,
-  delay: _react2.default.PropTypes.number,
+  filter: _propTypes2.default.string,
+  delay: _propTypes2.default.number,
 
-  disabled: _propTypes2.default.disabled.acceptsArray,
-  readOnly: _propTypes2.default.readOnly.acceptsArray,
+  disabled: _propTypes4.default.disabled.acceptsArray,
+  readOnly: _propTypes4.default.readOnly.acceptsArray,
 
-  messages: _react2.default.PropTypes.shape({
-    emptyList: _react2.default.PropTypes.string
+  messages: _propTypes2.default.shape({
+    emptyList: _propTypes2.default.string
   })
 };
 
@@ -136,7 +144,7 @@ function getFirstValue(props) {
   return null;
 }
 
-var SelectList = _react2.default.createClass((_obj = {
+var SelectList = (0, _createReactClass2.default)((_obj = {
   displayName: 'SelectList',
 
 
@@ -394,7 +402,7 @@ var SelectList = _react2.default.createClass((_obj = {
 
 function getListItem(parent) {
 
-  return _react2.default.createClass({
+  return (0, _createReactClass2.default)({
 
     displayName: 'SelectItem',
 

--- a/lib/SlideTransition.js
+++ b/lib/SlideTransition.js
@@ -2,6 +2,12 @@
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _class, _temp2, _class2, _temp4;
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -32,92 +38,103 @@ var _3 = _interopRequireDefault(_2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var SlideChildGroup = _react2.default.createClass({
-  displayName: 'SlideChildGroup',
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-  propTypes: {
-    direction: _react2.default.PropTypes.oneOf(['left', 'right']),
-    duration: _react2.default.PropTypes.number
-  },
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-  componentWillEnter: function componentWillEnter(done) {
-    var _this = this;
+var SlideChildGroup = (_temp2 = _class = function (_React$Component) {
+  _inherits(SlideChildGroup, _React$Component);
 
-    var node = _compat2.default.findDOMNode(this),
-        width = (0, _width2.default)(node),
-        direction = this.props.direction;
+  function SlideChildGroup() {
+    var _temp, _this, _ret;
 
-    width = direction === 'left' ? width : -width;
+    _classCallCheck(this, SlideChildGroup);
 
-    this.ORGINAL_POSITION = node.style.position;
+    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
 
-    (0, _style2.default)(node, { position: 'absolute', left: width + 'px', top: 0 });
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, _React$Component.call.apply(_React$Component, [this].concat(args))), _this), _this.componentWillEnter = function (done) {
+      var node = _compat2.default.findDOMNode(_this),
+          width = (0, _width2.default)(node),
+          direction = _this.props.direction;
 
-    _configuration2.default.animate(node, { left: 0 }, this.props.duration, function () {
+      width = direction === 'left' ? width : -width;
 
-      (0, _style2.default)(node, {
-        position: _this.ORGINAL_POSITION,
-        overflow: 'hidden'
+      _this.ORGINAL_POSITION = node.style.position;
+
+      (0, _style2.default)(node, { position: 'absolute', left: width + 'px', top: 0 });
+
+      _configuration2.default.animate(node, { left: 0 }, _this.props.duration, function () {
+
+        (0, _style2.default)(node, {
+          position: _this.ORGINAL_POSITION,
+          overflow: 'hidden'
+        });
+
+        _this.ORGINAL_POSITION = null;
+        done && done();
       });
+    }, _this.componentWillLeave = function (done) {
+      var node = _compat2.default.findDOMNode(_this),
+          width = (0, _width2.default)(node),
+          direction = _this.props.direction;
 
-      _this.ORGINAL_POSITION = null;
-      done && done();
-    });
-  },
-  componentWillLeave: function componentWillLeave(done) {
-    var _this2 = this;
+      width = direction === 'left' ? -width : width;
 
-    var node = _compat2.default.findDOMNode(this),
-        width = (0, _width2.default)(node),
-        direction = this.props.direction;
+      _this.ORGINAL_POSITION = node.style.position;
 
-    width = direction === 'left' ? -width : width;
+      (0, _style2.default)(node, { position: 'absolute', top: 0, left: 0 });
 
-    this.ORGINAL_POSITION = node.style.position;
+      _configuration2.default.animate(node, { left: width + 'px' }, _this.props.duration, function () {
+        (0, _style2.default)(node, {
+          position: _this.ORGINAL_POSITION,
+          overflow: 'hidden'
+        });
 
-    (0, _style2.default)(node, { position: 'absolute', top: 0, left: 0 });
-
-    _configuration2.default.animate(node, { left: width + 'px' }, this.props.duration, function () {
-      (0, _style2.default)(node, {
-        position: _this2.ORGINAL_POSITION,
-        overflow: 'hidden'
+        _this.ORGINAL_POSITION = null;
+        done && done();
       });
-
-      _this2.ORGINAL_POSITION = null;
-      done && done();
-    });
-  },
-  render: function render() {
-    return _react2.default.Children.only(this.props.children);
+    }, _temp), _possibleConstructorReturn(_this, _ret);
   }
-});
 
-module.exports = _react2.default.createClass({
-  displayName: 'exports',
+  SlideChildGroup.prototype.render = function render() {
+    return _react2.default.Children.only(this.props.children);
+  };
+
+  return SlideChildGroup;
+}(_react2.default.Component), _class.propTypes = {
+  direction: _propTypes2.default.oneOf(['left', 'right']),
+  duration: _propTypes2.default.number
+}, _temp2);
 
 
-  propTypes: {
-    direction: _react2.default.PropTypes.oneOf(['left', 'right']),
-    duration: _react2.default.PropTypes.number
-  },
+module.exports = (_temp4 = _class2 = function (_React$Component2) {
+  _inherits(_class2, _React$Component2);
 
-  getDefaultProps: function getDefaultProps() {
-    return {
-      direction: 'left',
-      duration: 250
-    };
-  },
-  _wrapChild: function _wrapChild(child, ref) {
-    return _react2.default.createElement(
-      SlideChildGroup,
-      { key: child.key, ref: ref,
-        direction: this.props.direction,
-        duration: this.props.duration },
-      child
-    );
-  },
-  render: function render() {
+  function _class2() {
+    var _temp3, _this2, _ret2;
+
+    _classCallCheck(this, _class2);
+
+    for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+      args[_key2] = arguments[_key2];
+    }
+
+    return _ret2 = (_temp3 = (_this2 = _possibleConstructorReturn(this, _React$Component2.call.apply(_React$Component2, [this].concat(args))), _this2), _this2._wrapChild = function (child, ref) {
+      return _react2.default.createElement(
+        SlideChildGroup,
+        { key: child.key, ref: ref,
+          direction: _this2.props.direction,
+          duration: _this2.props.duration },
+        child
+      );
+    }, _temp3), _possibleConstructorReturn(_this2, _ret2);
+  }
+
+  _class2.prototype.render = function render() {
     var _props = this.props,
         style = _props.style,
         children = _props.children;
@@ -138,5 +155,13 @@ module.exports = _react2.default.createClass({
       }),
       children
     );
-  }
-});
+  };
+
+  return _class2;
+}(_react2.default.Component), _class2.propTypes = {
+  direction: _propTypes2.default.oneOf(['left', 'right']),
+  duration: _propTypes2.default.number
+}, _class2.defaultProps = {
+  direction: 'left',
+  duration: 250
+}, _temp4);

--- a/lib/TimeList.js
+++ b/lib/TimeList.js
@@ -4,9 +4,17 @@ exports.__esModule = true;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _dates2 = require('./util/dates');
 
@@ -18,9 +26,9 @@ var _List2 = _interopRequireDefault(_List);
 
 var _localizers = require('./util/localizers');
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _2 = require('./util/_');
 
@@ -32,24 +40,24 @@ var format = function format(props) {
   return _localizers.date.getFormat('time', props.format);
 };
 
-exports.default = _react2.default.createClass({
+exports.default = (0, _createReactClass2.default)({
 
   displayName: 'TimeList',
 
   propTypes: {
-    value: _react2.default.PropTypes.instanceOf(Date),
-    step: _react2.default.PropTypes.number,
-    min: _react2.default.PropTypes.instanceOf(Date),
-    max: _react2.default.PropTypes.instanceOf(Date),
-    currentDate: _react2.default.PropTypes.instanceOf(Date),
-    offsetMinutes: _react2.default.PropTypes.number,
+    value: _propTypes2.default.instanceOf(Date),
+    step: _propTypes2.default.number,
+    min: _propTypes2.default.instanceOf(Date),
+    max: _propTypes2.default.instanceOf(Date),
+    currentDate: _propTypes2.default.instanceOf(Date),
+    offsetMinutes: _propTypes2.default.number,
 
-    itemComponent: _propTypes2.default.elementType,
-    format: _propTypes2.default.dateFormat,
-    onSelect: _react2.default.PropTypes.func,
-    preserveDate: _react2.default.PropTypes.bool,
-    culture: _react2.default.PropTypes.string,
-    delay: _react2.default.PropTypes.number
+    itemComponent: _propTypes4.default.elementType,
+    format: _propTypes4.default.dateFormat,
+    onSelect: _propTypes2.default.func,
+    preserveDate: _propTypes2.default.bool,
+    culture: _propTypes2.default.string,
+    delay: _propTypes2.default.number
   },
 
   mixins: [require('./mixins/TimeoutMixin')],

--- a/lib/Widget.js
+++ b/lib/Widget.js
@@ -6,6 +6,10 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 var _class, _temp;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -57,14 +61,14 @@ var Widget = (_temp = _class = function (_React$Component) {
 
   return Widget;
 }(_react2.default.Component), _class.propTypes = {
-  tabIndex: _react.PropTypes.node,
-  focused: _react.PropTypes.bool,
-  disabled: _react.PropTypes.bool,
-  readOnly: _react.PropTypes.bool,
-  open: _react.PropTypes.bool,
-  dropUp: _react.PropTypes.bool
+  tabIndex: _propTypes2.default.node,
+  focused: _propTypes2.default.bool,
+  disabled: _propTypes2.default.bool,
+  readOnly: _propTypes2.default.bool,
+  open: _propTypes2.default.bool,
+  dropUp: _propTypes2.default.bool
 }, _class.contextTypes = {
-  isRtl: _react.PropTypes.bool
+  isRtl: _propTypes2.default.bool
 }, _temp);
 exports.default = Widget;
 module.exports = exports['default'];

--- a/lib/Year.js
+++ b/lib/Year.js
@@ -2,9 +2,17 @@
 
 exports.__esModule = true;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _CalendarView = require('./CalendarView');
 
@@ -20,9 +28,9 @@ var _2 = require('./util/_');
 
 var _3 = _interopRequireDefault(_2);
 
-var _propTypes = require('./util/propTypes');
+var _propTypes3 = require('./util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _widgetHelpers = require('./util/widgetHelpers');
 
@@ -33,22 +41,22 @@ var format = function format(props) {
 };
 
 var propTypes = {
-  culture: _react2.default.PropTypes.string,
-  today: _react2.default.PropTypes.instanceOf(Date),
-  value: _react2.default.PropTypes.instanceOf(Date),
-  focused: _react2.default.PropTypes.instanceOf(Date),
-  min: _react2.default.PropTypes.instanceOf(Date),
-  max: _react2.default.PropTypes.instanceOf(Date),
-  onChange: _react2.default.PropTypes.func.isRequired,
+  culture: _propTypes2.default.string,
+  today: _propTypes2.default.instanceOf(Date),
+  value: _propTypes2.default.instanceOf(Date),
+  focused: _propTypes2.default.instanceOf(Date),
+  min: _propTypes2.default.instanceOf(Date),
+  max: _propTypes2.default.instanceOf(Date),
+  onChange: _propTypes2.default.func.isRequired,
 
-  monthFormat: _propTypes2.default.dateFormat
+  monthFormat: _propTypes4.default.dateFormat
 };
 
 var optionId = function optionId(id, date) {
   return id + '__year_' + _dates2.default.year(date) + '-' + _dates2.default.month(date);
 };
 
-var YearView = _react2.default.createClass({
+var YearView = (0, _createReactClass2.default)({
 
   displayName: 'YearView',
 

--- a/lib/localizers/globalize.js
+++ b/lib/localizers/globalize.js
@@ -3,7 +3,9 @@
 exports.__esModule = true;
 exports.default = globalizeLocalizers;
 
-var _react = require('react');
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _configure = require('../configure');
 
@@ -59,7 +61,7 @@ function newGlobalize(globalize) {
       }
     },
 
-    propType: _react.PropTypes.oneOfType([_react.PropTypes.string, _react.PropTypes.object, _react.PropTypes.func]),
+    propType: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.object, _propTypes2.default.func]),
 
     firstOfWeek: function firstOfWeek(culture) {
       var date = new Date();
@@ -83,7 +85,7 @@ function newGlobalize(globalize) {
       default: { maximumFractionDigits: 0 }
     },
 
-    propType: _react.PropTypes.oneOfType([_react.PropTypes.object, _react.PropTypes.func]),
+    propType: _propTypes2.default.oneOfType([_propTypes2.default.object, _propTypes2.default.func]),
 
     // TODO major bump consistent ordering
     parse: function parse(value, culture) {

--- a/lib/mixins/AriaDescendantMixin.js
+++ b/lib/mixins/AriaDescendantMixin.js
@@ -8,7 +8,7 @@ exports.default = function (nodeOrComponent) {
 
   return {
     propTypes: {
-      ariaActiveDescendantKey: _react2.default.PropTypes.string.isRequired
+      ariaActiveDescendantKey: _propTypes2.default.string.isRequired
     },
 
     contextTypes: {
@@ -50,6 +50,10 @@ exports.default = function (nodeOrComponent) {
   };
 };
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -60,9 +64,9 @@ var _compat2 = _interopRequireDefault(_compat);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var shape = _react2.default.PropTypes.shape({
+var shape = _propTypes2.default.shape({
   //setActive: React.PropTypes.func,
-  reconcile: _react2.default.PropTypes.func
+  reconcile: _propTypes2.default.func
 });
 
 function defaultReconcile(key, id) {

--- a/lib/mixins/AutoFocusMixin.js
+++ b/lib/mixins/AutoFocusMixin.js
@@ -2,6 +2,10 @@
 
 exports.__esModule = true;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -12,7 +16,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 exports.default = {
   propTypes: {
-    autoFocus: _react2.default.PropTypes.bool
+    autoFocus: _propTypes2.default.bool
   },
 
   componentDidMount: function componentDidMount() {

--- a/lib/mixins/DataFilterMixin.js
+++ b/lib/mixins/DataFilterMixin.js
@@ -1,5 +1,9 @@
 'use strict';
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -8,9 +12,9 @@ var _filter = require('../util/filter');
 
 var _filter2 = _interopRequireDefault(_filter);
 
-var _propTypes = require('../util/propTypes');
+var _propTypes3 = require('../util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _dataHelpers = require('../util/dataHelpers');
 
@@ -23,11 +27,11 @@ var dflt = function dflt(f) {
 module.exports = {
 
   propTypes: {
-    data: _react2.default.PropTypes.array,
-    value: _react2.default.PropTypes.any,
-    filter: _propTypes2.default.filter,
-    caseSensitive: _react2.default.PropTypes.bool,
-    minLength: _react2.default.PropTypes.number
+    data: _propTypes2.default.array,
+    value: _propTypes2.default.any,
+    filter: _propTypes4.default.filter,
+    caseSensitive: _propTypes2.default.bool,
+    minLength: _propTypes2.default.number
   },
 
   getDefaultProps: function getDefaultProps() {

--- a/lib/mixins/DataHelpersMixin.js
+++ b/lib/mixins/DataHelpersMixin.js
@@ -2,6 +2,10 @@
 
 exports.__esModule = true;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -10,9 +14,9 @@ var _warning = require('warning');
 
 var _warning2 = _interopRequireDefault(_warning);
 
-var _propTypes = require('../util/propTypes');
+var _propTypes3 = require('../util/propTypes');
 
-var _propTypes2 = _interopRequireDefault(_propTypes);
+var _propTypes4 = _interopRequireDefault(_propTypes3);
 
 var _dataHelpers = require('../util/dataHelpers');
 
@@ -25,8 +29,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 exports.default = {
 
   propTypes: {
-    valueField: _react2.default.PropTypes.string,
-    textField: _propTypes2.default.accessor
+    valueField: _propTypes2.default.string,
+    textField: _propTypes4.default.accessor
   },
 
   componentWillMount: function componentWillMount() {

--- a/lib/mixins/RtlChildContextMixin.js
+++ b/lib/mixins/RtlChildContextMixin.js
@@ -2,6 +2,10 @@
 
 exports.__esModule = true;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -11,7 +15,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 exports.default = {
 
   contextTypes: {
-    isRtl: _react2.default.PropTypes.bool
+    isRtl: _propTypes2.default.bool
   },
 
   isRtl: function isRtl() {

--- a/lib/mixins/RtlParentContextMixin.js
+++ b/lib/mixins/RtlParentContextMixin.js
@@ -1,19 +1,20 @@
 'use strict';
 
+var PropTypes = require('prop-types');
 var React = require('react');
 
 module.exports = {
 
   propTypes: {
-    isRtl: React.PropTypes.bool
+    isRtl: PropTypes.bool
   },
 
   contextTypes: {
-    isRtl: React.PropTypes.bool
+    isRtl: PropTypes.bool
   },
 
   childContextTypes: {
-    isRtl: React.PropTypes.bool
+    isRtl: PropTypes.bool
   },
 
   getChildContext: function getChildContext() {

--- a/lib/util/localizers.js
+++ b/lib/util/localizers.js
@@ -10,13 +10,17 @@ var _invariant2 = _interopRequireDefault(_invariant);
 
 var _ = require('./_');
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var localePropType = _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.func]);
+var localePropType = _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.func]);
 
 var REQUIRED_NUMBER_FORMATS = ['default'];
 

--- a/lib/util/propTypes.js
+++ b/lib/util/propTypes.js
@@ -1,5 +1,9 @@
 'use strict';
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -19,10 +23,10 @@ var filterTypes = Object.keys(_filter2.default).filter(function (i) {
 });
 
 function getInteractionPropType(key) {
-  var types = [_react.PropTypes.bool, _react.PropTypes.oneOf([key])],
-      propType = _react.PropTypes.oneOfType(types);
+  var types = [_propTypes2.default.bool, _propTypes2.default.oneOf([key])],
+      propType = _propTypes2.default.oneOfType(types);
 
-  propType.acceptsArray = _react.PropTypes.oneOfType(types.concat(_react.PropTypes.array));
+  propType.acceptsArray = _propTypes2.default.oneOfType(types.concat(_propTypes2.default.array));
 
   return propType;
 }
@@ -54,11 +58,11 @@ module.exports = {
   disabled: getInteractionPropType('disabled'),
   readOnly: getInteractionPropType('readOnly'),
 
-  accessor: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.func]),
+  accessor: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.func]),
 
-  message: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.node, _react2.default.PropTypes.string]),
+  message: _propTypes2.default.oneOfType([_propTypes2.default.node, _propTypes2.default.string]),
 
-  filter: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.func, _react2.default.PropTypes.bool, _react2.default.PropTypes.oneOf(filterTypes)])
+  filter: _propTypes2.default.oneOfType([_propTypes2.default.func, _propTypes2.default.bool, _propTypes2.default.oneOf(filterTypes)])
 };
 
 function createChainableTypeChecker(validate) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-widgets",
-  "version": "3.4.6-fork.1.0",
+  "version": "3.4.6-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-widgets",
+  "name": "@lacework/react-widgets-fork",
   "version": "3.4.6-0",
   "lockfileVersion": 1,
   "requires": true,
@@ -787,6 +787,12 @@
       "requires": {
         "babel-runtime": "^6.22.0"
       }
+    },
+    "babel-plugin-react-require": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-require/-/babel-plugin-react-require-3.1.3.tgz",
+      "integrity": "sha512-kDXhW2iPTL81x4Ye2aUMdEXQ56JP0sBJmRQRXJPH5FsNB7fOc/YCsHTqHv8IovPyw9Rk07gdd7MVUz8tUmRBCA==",
+      "dev": true
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11128 @@
+{
+  "name": "react-widgets",
+  "version": "3.4.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/runtime": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
+    "@monastic.panic/component-playground": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@monastic.panic/component-playground/-/component-playground-2.0.0.tgz",
+      "integrity": "sha1-eMIsQV2/+xp6ONbPwlsDaREHveM=",
+      "dev": true,
+      "requires": {
+        "babel-standalone": "^6.7.4",
+        "codemirror": "^5.13.4",
+        "lodash": "^3.10.0",
+        "prismjs": "^1.4.1"
+      }
+    },
+    "abab": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+      "dev": true
+    },
+    "accepts": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.11",
+        "negotiator": "0.6.1"
+      }
+    },
+    "acorn": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
+      "dev": true
+    },
+    "acorn-globals": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+      "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
+      "dev": true,
+      "requires": {
+        "acorn": "^2.1.0"
+      }
+    },
+    "adm-zip": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+      "dev": true
+    },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+      "dev": true
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "alphanum-sort": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "any-promise": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz",
+      "integrity": "sha1-gwtoCqflbzNFHUsEnzvYBESY7ic=",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
+      }
+    },
+    "archiver": {
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.14.4.tgz",
+      "integrity": "sha1-W53bn17hzu8hy487Ag5iQOy0MVw=",
+      "dev": true,
+      "requires": {
+        "async": "~0.9.0",
+        "buffer-crc32": "~0.2.1",
+        "glob": "~4.3.0",
+        "lazystream": "~0.1.0",
+        "lodash": "~3.2.0",
+        "readable-stream": "~1.0.26",
+        "tar-stream": "~1.1.0",
+        "zip-stream": "~0.5.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        },
+        "glob": {
+          "version": "4.3.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+          "integrity": "sha1-gPuwjKVA8jiszl0R0em8QedRc9M=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^2.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
+          "integrity": "sha1-S/UKMkP5rrC6xBpV09WZBnWkYvs=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.0.1"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
+    "array-slice": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
+    },
+    "arraybuffer.slice": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        }
+      }
+    },
+    "assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "util": "0.10.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1"
+          }
+        }
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "autoprefixer": {
+      "version": "6.7.7",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+      "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^1.7.6",
+        "caniuse-db": "^1.0.30000634",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^5.2.16",
+        "postcss-value-parser": "^3.2.3"
+      }
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true
+    },
+    "babel-cli": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
+      "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "^6.26.0",
+        "babel-polyfill": "^6.26.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "chokidar": "^1.6.1",
+        "commander": "^2.11.0",
+        "convert-source-map": "^1.5.0",
+        "fs-readdir-recursive": "^1.0.0",
+        "glob": "^7.1.2",
+        "lodash": "^4.17.4",
+        "output-file-sync": "^1.1.2",
+        "path-is-absolute": "^1.0.1",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6",
+        "v8flags": "^2.1.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        }
+      }
+    },
+    "babel-core": {
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-eslint": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
+      "integrity": "sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8=",
+      "dev": true,
+      "requires": {
+        "babel-traverse": "^6.0.20",
+        "babel-types": "^6.0.19",
+        "babylon": "^6.0.18",
+        "lodash.assign": "^4.0.0",
+        "lodash.pickby": "^4.0.0"
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "dev": true,
+      "requires": {
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-bindify-decorators": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
+      "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-builder-react-jsx": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
+      "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "esutils": "^2.0.2"
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-define-map": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-explode-class": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
+      "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+      "dev": true,
+      "requires": {
+        "babel-helper-bindify-decorators": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "dev": true,
+      "requires": {
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-loader": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
+      "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "^0.1.1",
+        "loader-utils": "^0.2.16",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-add-module-exports": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.1.4.tgz",
+      "integrity": "sha1-Glttdh7h9mPYRbTqaHhxLeMcEHo=",
+      "dev": true,
+      "requires": {
+        "babel-template": "^6.5.0"
+      }
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
+    },
+    "babel-plugin-syntax-async-generators": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+      "dev": true
+    },
+    "babel-plugin-syntax-class-constructor-call": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
+      "integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
+      "dev": true
+    },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+      "dev": true
+    },
+    "babel-plugin-syntax-decorators": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+      "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
+      "dev": true
+    },
+    "babel-plugin-syntax-do-expressions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
+      "integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0=",
+      "dev": true
+    },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+      "dev": true
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
+    "babel-plugin-syntax-export-extensions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
+      "integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
+      "dev": true
+    },
+    "babel-plugin-syntax-flow": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+      "dev": true
+    },
+    "babel-plugin-syntax-function-bind": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
+      "integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y=",
+      "dev": true
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+      "dev": true
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
+    },
+    "babel-plugin-transform-async-generator-functions": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
+      "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-generators": "^6.5.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-class-constructor-call": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
+      "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-class-constructor-call": "^6.18.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-decorators": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
+      "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-class": "^6.24.1",
+        "babel-plugin-syntax-decorators": "^6.13.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-decorators-legacy": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators-legacy/-/babel-plugin-transform-decorators-legacy-1.3.5.tgz",
+      "integrity": "sha512-jYHwjzRXRelYQ1uGm353zNzf3QmtdCfvJbuYTZ4gKveK7M9H1fs3a5AKdY1JUDl0z97E30ukORW1dzhWvsabtA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-decorators": "^6.1.18",
+        "babel-runtime": "^6.2.0",
+        "babel-template": "^6.3.0"
+      }
+    },
+    "babel-plugin-transform-do-expressions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz",
+      "integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-do-expressions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "dev": true,
+      "requires": {
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
+      }
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-export-extensions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
+      "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-export-extensions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-flow-strip-types": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
+      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-flow": "^6.18.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-function-bind": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
+      "integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-function-bind": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-object-assign": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz",
+      "integrity": "sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
+      }
+    },
+    "babel-plugin-transform-react-display-name": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
+      "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-react-jsx": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
+      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-react-jsx": "^6.24.1",
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-react-jsx-self": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
+      "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-react-jsx-source": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
+      "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.10.0"
+      }
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
+    "babel-preset-es2015": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.24.1",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+        "babel-plugin-transform-es2015-object-super": "^6.24.1",
+        "babel-plugin-transform-es2015-parameters": "^6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+        "babel-plugin-transform-regenerator": "^6.24.1"
+      }
+    },
+    "babel-preset-es2015-loose": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015-loose/-/babel-preset-es2015-loose-7.0.0.tgz",
+      "integrity": "sha1-/YDIXTsgy/MJvQzjCjY4DFeEvwY=",
+      "dev": true,
+      "requires": {
+        "modify-babel-preset": "^1.0.0"
+      }
+    },
+    "babel-preset-flow": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
+      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-flow-strip-types": "^6.22.0"
+      }
+    },
+    "babel-preset-jason": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-jason/-/babel-preset-jason-1.0.1.tgz",
+      "integrity": "sha1-l009O93Uzll7P1jAi71Cvb6JAmo=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-add-module-exports": "^0.1.2",
+        "babel-plugin-transform-object-assign": "^6.5.0",
+        "babel-preset-es2015-loose": "^7.0.0",
+        "babel-preset-react": "^6.5.0",
+        "babel-preset-stage-0": "^6.5.0"
+      }
+    },
+    "babel-preset-react": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
+      "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "^6.3.13",
+        "babel-plugin-transform-react-display-name": "^6.23.0",
+        "babel-plugin-transform-react-jsx": "^6.24.1",
+        "babel-plugin-transform-react-jsx-self": "^6.22.0",
+        "babel-plugin-transform-react-jsx-source": "^6.22.0",
+        "babel-preset-flow": "^6.23.0"
+      }
+    },
+    "babel-preset-stage-0": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz",
+      "integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-do-expressions": "^6.22.0",
+        "babel-plugin-transform-function-bind": "^6.22.0",
+        "babel-preset-stage-1": "^6.24.1"
+      }
+    },
+    "babel-preset-stage-1": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
+      "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-class-constructor-call": "^6.24.1",
+        "babel-plugin-transform-export-extensions": "^6.22.0",
+        "babel-preset-stage-2": "^6.24.1"
+      }
+    },
+    "babel-preset-stage-2": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
+      "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-decorators": "^6.24.1",
+        "babel-preset-stage-3": "^6.24.1"
+      }
+    },
+    "babel-preset-stage-3": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
+      "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-generator-functions": "^6.24.1",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+        "babel-plugin-transform-object-rest-spread": "^6.22.0"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "babel-standalone": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-standalone/-/babel-standalone-6.26.0.tgz",
+      "integrity": "sha1-Ffs9NfLEVmlYFevx7Zb+fwFbaIY=",
+      "dev": true
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
+    },
+    "base64-arraybuffer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "base64id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+      "dev": true
+    },
+    "batch": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
+      "integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "better-assert": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "dev": true,
+      "requires": {
+        "callsite": "1.0.0"
+      }
+    },
+    "big.js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "dev": true
+    },
+    "bill": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/bill/-/bill-3.2.6.tgz",
+      "integrity": "sha1-dx26TTj9j6alkUaJx+bBZZjq4kM=",
+      "dev": true,
+      "requires": {
+        "css-selector-parser": "^1.1.0",
+        "escape-regexp": "0.0.1",
+        "fn-name": "^2.0.1",
+        "lodash": "^3.10.1",
+        "semver": "^5.1.0"
+      }
+    },
+    "binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~1.0.26"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "blob": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+      "dev": true
+    },
+    "bn.js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+      "dev": true
+    },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      }
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true,
+      "requires": {
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
+      }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
+    },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "requires": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^5.0.0",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "browserify-sign": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.3",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
+      }
+    },
+    "browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "dev": true,
+      "requires": {
+        "pako": "~0.2.0"
+      }
+    },
+    "browserslist": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+      "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+      "dev": true,
+      "requires": {
+        "caniuse-db": "^1.0.30000639",
+        "electron-to-chromium": "^1.2.7"
+      }
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dev": true,
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "dev": true
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      }
+    },
+    "caniuse-api": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+      "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^1.3.6",
+        "caniuse-db": "^1.0.30000529",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "caniuse-db": {
+      "version": "1.0.30001226",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001226.tgz",
+      "integrity": "sha512-hnC3hnMKAn/VaRHFb4fCe7snQRQFy0EZrK0AAomFbqGT18KXOtnPvTm0m+NvyRrBCR1jwFCjbUQvar0r6lBvOw==",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "requires": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "chance": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.7.tgz",
+      "integrity": "sha512-bua/2cZEfzS6qPm0vi3JEvGNbriDLcMj9lKxCQOjUcCJRcyjA7umP0zZm6bKWWlBN04vA0L99QGH/CZQawr0eg==",
+      "dev": true
+    },
+    "child-process-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/child-process-promise/-/child-process-promise-1.1.0.tgz",
+      "integrity": "sha1-Ex4BpwXxXtSgXVVN1eAy5SYSzzA=",
+      "dev": true,
+      "requires": {
+        "q": "^1.1.2"
+      }
+    },
+    "chokidar": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "dev": true,
+      "requires": {
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
+      }
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "clap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3"
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^1.0.1"
+      }
+    },
+    "cli-width": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
+      "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
+      "dev": true
+    },
+    "clipboard": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
+      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true,
+      "optional": true
+    },
+    "coa": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+      "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+      "dev": true,
+      "requires": {
+        "q": "^1.1.2"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "codemirror": {
+      "version": "5.61.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.0.tgz",
+      "integrity": "sha512-D3wYH90tYY1BsKlUe0oNj2JAhQ9TepkD51auk3N7q+4uz7A/cgJ5JsWHreT0PqieW1QhOuqxQ2reCXV1YXzecg==",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+      "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2",
+        "color-convert": "^1.3.0",
+        "color-string": "^0.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "color-string": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0"
+      }
+    },
+    "colormin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+      "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+      "dev": true,
+      "requires": {
+        "color": "^0.11.0",
+        "css-color-names": "0.0.4",
+        "has": "^1.0.1"
+      }
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
+      "dev": true
+    },
+    "compress-commons": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.9.tgz",
+      "integrity": "sha1-Qi2SdDDAGr0GzUVbbfwEy0z4ADw=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.1",
+        "crc32-stream": "~0.3.1",
+        "node-int64": "~0.3.0",
+        "readable-stream": "~1.0.26"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+          "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+          "dev": true,
+          "requires": {
+            "mime-types": "~2.1.24",
+            "negotiator": "0.6.2"
+          }
+        },
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+          "dev": true
+        },
+        "negotiator": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+          "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+          "dev": true
+        }
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "connect": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.2",
+        "parseurl": "~1.3.3",
+        "utils-merge": "1.0.1"
+      }
+    },
+    "connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+      "dev": true
+    },
+    "console-browserify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
+    },
+    "constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+      "dev": true
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cp-file": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-3.2.0.tgz",
+      "integrity": "sha1-b4NhYlRiTwrViqSqjQdvAmvn4Yg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nested-error-stacks": "^1.0.1",
+        "object-assign": "^4.0.1",
+        "pify": "^2.3.0",
+        "pinkie-promise": "^2.0.0",
+        "readable-stream": "^2.1.4"
+      }
+    },
+    "cpy": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cpy/-/cpy-4.0.1.tgz",
+      "integrity": "sha1-tnJn66LzlgugalphrJQDNCKDNCQ=",
+      "dev": true,
+      "requires": {
+        "cp-file": "^3.1.0",
+        "globby": "^4.0.0",
+        "meow": "^3.6.0",
+        "nested-error-stacks": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "cpy-cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cpy-cli/-/cpy-cli-1.0.1.tgz",
+      "integrity": "sha1-Z/taSi3sKMqKv/N13kuecfanVhw=",
+      "dev": true,
+      "requires": {
+        "cpy": "^4.0.0",
+        "meow": "^3.6.0"
+      }
+    },
+    "crc32-stream": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
+      "integrity": "sha1-c7wltF+sHbZjIjGnv86JJ+nwZVI=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.1",
+        "readable-stream": "~1.0.24"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        }
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "create-react-class": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
+      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
+      "requires": {
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "requires": {
+        "boom": "2.x.x"
+      }
+    },
+    "crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "dev": true,
+      "requires": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      }
+    },
+    "css-color-names": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+      "dev": true
+    },
+    "css-loader": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.23.1.tgz",
+      "integrity": "sha1-n6I/K1wJZSNZEK1ezvO4o2OQ/lA=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "^0.5.1",
+        "cssnano": ">=2.6.1 <4",
+        "loader-utils": "~0.2.2",
+        "lodash.camelcase": "^3.0.1",
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.6",
+        "postcss-modules-extract-imports": "^1.0.0",
+        "postcss-modules-local-by-default": "^1.0.1",
+        "postcss-modules-scope": "^1.0.0",
+        "postcss-modules-values": "^1.1.0",
+        "source-list-map": "^0.1.4"
+      }
+    },
+    "css-selector-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
+      "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==",
+      "dev": true
+    },
+    "css-selector-tokenizer": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
+      "integrity": "sha1-E5uv00o1/QwUKEhwSeBpnm9qLCE=",
+      "dev": true,
+      "requires": {
+        "cssesc": "^0.1.0",
+        "fastparse": "^1.1.1"
+      }
+    },
+    "cssesc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+      "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+      "dev": true
+    },
+    "cssnano": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+      "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+      "dev": true,
+      "requires": {
+        "autoprefixer": "^6.3.1",
+        "decamelize": "^1.1.2",
+        "defined": "^1.0.0",
+        "has": "^1.0.1",
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.14",
+        "postcss-calc": "^5.2.0",
+        "postcss-colormin": "^2.1.8",
+        "postcss-convert-values": "^2.3.4",
+        "postcss-discard-comments": "^2.0.4",
+        "postcss-discard-duplicates": "^2.0.1",
+        "postcss-discard-empty": "^2.0.1",
+        "postcss-discard-overridden": "^0.1.1",
+        "postcss-discard-unused": "^2.2.1",
+        "postcss-filter-plugins": "^2.0.0",
+        "postcss-merge-idents": "^2.1.5",
+        "postcss-merge-longhand": "^2.0.1",
+        "postcss-merge-rules": "^2.0.3",
+        "postcss-minify-font-values": "^1.0.2",
+        "postcss-minify-gradients": "^1.0.1",
+        "postcss-minify-params": "^1.0.4",
+        "postcss-minify-selectors": "^2.0.4",
+        "postcss-normalize-charset": "^1.1.0",
+        "postcss-normalize-url": "^3.0.7",
+        "postcss-ordered-values": "^2.1.0",
+        "postcss-reduce-idents": "^2.2.2",
+        "postcss-reduce-initial": "^1.0.0",
+        "postcss-reduce-transforms": "^1.0.3",
+        "postcss-svgo": "^2.1.1",
+        "postcss-unique-selectors": "^2.0.2",
+        "postcss-value-parser": "^3.2.3",
+        "postcss-zindex": "^2.0.1"
+      }
+    },
+    "csso": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+      "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+      "dev": true,
+      "requires": {
+        "clap": "^1.0.9",
+        "source-map": "^0.5.3"
+      }
+    },
+    "cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.x"
+      }
+    },
+    "ctype": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
+      "dev": true
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
+    "custom-event": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
+      "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
+      "dev": true
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "date-arithmetic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-3.1.0.tgz",
+      "integrity": "sha1-H80D29UEudvuK5B4yFpfHH08wtM="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "deconstruct-number-format": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deconstruct-number-format/-/deconstruct-number-format-0.0.1.tgz",
+      "integrity": "sha1-+7XX3NRb0rL6Dlee2RtZx+KbOGo=",
+      "optional": true
+    },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true,
+      "optional": true
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "des.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "di": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
+      "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
+      "dev": true
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        }
+      }
+    },
+    "doctrine": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+      "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+      "dev": true,
+      "requires": {
+        "esutils": "^1.1.6",
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "esutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
+    "dom-helpers": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-2.4.0.tgz",
+      "integrity": "sha1-m7SyRfY3NnsfpnAnQnKqKP4Gw2c="
+    },
+    "dom-serialize": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
+      "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
+      "dev": true,
+      "requires": {
+        "custom-event": "~1.0.0",
+        "ent": "~2.2.0",
+        "extend": "^3.0.0",
+        "void-elements": "^2.0.0"
+      }
+    },
+    "domain-browser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.727",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
+      "integrity": "sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg==",
+      "dev": true
+    },
+    "elliptic": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        }
+      }
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "engine.io": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.5.tgz",
+      "integrity": "sha512-j1DWIcktw4hRwrv6nWx++5nFH2X64x16MAG2P0Lmi5Dvdfi3I+Jhc7JKJIdAmDJa+5aZ/imHV7dWRPy2Cqjh3A==",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.3",
+        "base64id": "1.0.0",
+        "cookie": "0.3.1",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.2",
+        "ws": "~1.1.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        }
+      }
+    },
+    "engine.io-client": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.5.tgz",
+      "integrity": "sha512-AYTgHyeVUPitsseqjoedjhYJapNVoSPShbZ+tEUX9/73jgZ/Z3sUlJf9oYgdEBBdVhupUpUqSxH0kBCXlQnmZg==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parsejson": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "~1.1.5",
+        "xmlhttprequest-ssl": "1.5.3",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
+      "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
+      "dev": true,
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "0.0.6",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.4",
+        "has-binary": "0.1.7",
+        "wtf-8": "1.0.0"
+      }
+    },
+    "enhanced-resolve": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+      "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.2.0",
+        "tapable": "^0.1.8"
+      },
+      "dependencies": {
+        "memory-fs": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+          "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
+          "dev": true
+        }
+      }
+    },
+    "ent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+      "dev": true
+    },
+    "errno": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "dev": true,
+      "requires": {
+        "prr": "~1.0.1"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es5-shim": {
+      "version": "4.5.15",
+      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.15.tgz",
+      "integrity": "sha512-FYpuxEjMeDvU4rulKqFdukQyZSTpzhg4ScQHrAosrlVpR6GFyaw14f74yn2+4BugniIS0Frpg7TvwZocU4ZMTw==",
+      "dev": true
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      },
+      "dependencies": {
+        "es6-symbol": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+          "dev": true,
+          "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14"
+          }
+        }
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
+    "escape-regexp": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/escape-regexp/-/escape-regexp-0.0.1.tgz",
+      "integrity": "sha1-9EvaEtRbvfnLf4Yu5+SCez3TIlQ=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+          "dev": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "optionator": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+          "dev": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "requires": {
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.10.3.tgz",
+      "integrity": "sha1-+xmpGxPBWAgrvKKUsX2Xm8g1Ogo=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0",
+        "concat-stream": "^1.4.6",
+        "debug": "^2.1.1",
+        "doctrine": "^0.7.1",
+        "escape-string-regexp": "^1.0.2",
+        "escope": "^3.3.0",
+        "espree": "^2.2.4",
+        "estraverse": "^4.1.1",
+        "estraverse-fb": "^1.3.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^1.1.1",
+        "glob": "^5.0.14",
+        "globals": "^8.11.0",
+        "handlebars": "^4.0.0",
+        "inquirer": "^0.11.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "3.4.5",
+        "json-stable-stringify": "^1.0.0",
+        "lodash.clonedeep": "^3.0.1",
+        "lodash.merge": "^3.3.2",
+        "lodash.omit": "^3.1.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "object-assign": "^4.0.1",
+        "optionator": "^0.6.0",
+        "path-is-absolute": "^1.0.0",
+        "path-is-inside": "^1.0.1",
+        "shelljs": "^0.5.3",
+        "strip-json-comments": "~1.0.1",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0",
+        "xml-escape": "~1.0.0"
+      },
+      "dependencies": {
+        "espree": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
+          "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
+          "dev": true
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "globals": {
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
+          "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.4.5",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.5.tgz",
+          "integrity": "sha1-w0A3l98SuRhmV08t4jZG/oyvtE0=",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.2",
+            "esprima": "^2.6.0"
+          }
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-mocha": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-1.1.0.tgz",
+      "integrity": "sha1-Ff8b8MhbJNslf3KGTtx4Zwk2azE=",
+      "dev": true,
+      "requires": {
+        "ramda": "^0.18.0"
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-4.3.0.tgz",
+      "integrity": "sha1-x5qsgGnWLeJ4h8E7gpjVkgiN43g=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "estraverse-fb": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
+      "integrity": "sha1-0yOky15awzHOoDNBOpJT4WQ+B8Q=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
+    },
+    "eventsource": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
+      "dev": true,
+      "requires": {
+        "original": "^1.0.0"
+      }
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "expand-braces": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
+      "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
+      "dev": true,
+      "requires": {
+        "array-slice": "^0.2.3",
+        "array-unique": "^0.2.1",
+        "braces": "^0.1.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
+          "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
+          "dev": true,
+          "requires": {
+            "expand-range": "^0.1.0"
+          }
+        },
+        "expand-range": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
+          "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
+          "dev": true,
+          "requires": {
+            "is-number": "^0.1.1",
+            "repeat-string": "^0.2.2"
+          }
+        },
+        "is-number": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
+          "integrity": "sha1-aaevEWlj1HIG7JvZtIoUIW8eOAY=",
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
+          "integrity": "sha1-x6jTI2BoNiBZp+RlH8aITosftK4=",
+          "dev": true
+        }
+      }
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "^0.1.0"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "^2.1.0"
+      }
+    },
+    "expect.js": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
+      "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
+      "dev": true
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+          "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+          "dev": true,
+          "requires": {
+            "mime-types": "~2.1.24",
+            "negotiator": "0.6.2"
+          }
+        },
+        "cookie": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+          "dev": true
+        },
+        "negotiator": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+          "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+          "dev": true
+        }
+      }
+    },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "dev": true,
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
+          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
+          "dev": true
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "extract-text-webpack-plugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-1.0.1.tgz",
+      "integrity": "sha1-yVvzy6rEnclvHcbgclSfu2VMzSw=",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.0",
+        "loader-utils": "^0.2.3",
+        "webpack-sources": "^0.1.0"
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+      "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+      "dev": true
+    },
+    "fastparse": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+      "dev": true
+    },
+    "faye-websocket": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+      "dev": true,
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "dev": true,
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        }
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "file-entry-cache": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "file-loader": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
+      "integrity": "sha1-knXQMf54DyfUf19K8CvUNxPMFRs=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "~0.2.5"
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "dev": true,
+      "requires": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "find-cache-dir": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+      "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pkg-dir": "^1.0.0"
+      }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatten": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
+      "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
+      "dev": true
+    },
+    "fn-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
+      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+      "dev": true
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "format-number": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/format-number/-/format-number-2.0.2.tgz",
+      "integrity": "sha1-i+Kqb6bvXsQ4MIkrHa7nJwX5tGI=",
+      "optional": true
+    },
+    "format-number-with-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/format-number-with-string/-/format-number-with-string-0.0.2.tgz",
+      "integrity": "sha1-65bo8WQMkh90FEZsz43LO7aALLo=",
+      "optional": true,
+      "requires": {
+        "deconstruct-number-format": "~0.0.1",
+        "format-number": "^2.0.1"
+      }
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "dev": true,
+      "requires": {
+        "samsam": "~1.1"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "fs-access": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
+      "dev": true,
+      "requires": {
+        "null-check": "^1.0.0"
+      }
+    },
+    "fs-promise": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-0.3.1.tgz",
+      "integrity": "sha1-vzQFA2jyTW3J38ZoirXOrY+GhCo=",
+      "dev": true,
+      "requires": {
+        "any-promise": "~0.1.0"
+      }
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "github-url-to-object": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/github-url-to-object/-/github-url-to-object-2.2.6.tgz",
+      "integrity": "sha1-ypJQFlFJdI7uswv8xgAMb+DSQvc=",
+      "dev": true,
+      "requires": {
+        "is-url": "^1.1.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
+      "requires": {
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^2.0.0"
+      }
+    },
+    "globalize": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/globalize/-/globalize-0.1.1.tgz",
+      "integrity": "sha1-TQS6ZaWAqLC9zJ7ZdK60l7nIClY=",
+      "dev": true
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+      "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^6.0.1",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-binary": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
+      }
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hawk": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+      "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
+      "dev": true,
+      "requires": {
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
+      }
+    },
+    "history": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/history/-/history-2.1.2.tgz",
+      "integrity": "sha1-SqLeiXoOSGfkU5hDvm7Nsphr/ew=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "^1.0.0",
+        "invariant": "^2.0.0",
+        "query-string": "^3.0.0",
+        "warning": "^2.0.0"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz",
+          "integrity": "sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=",
+          "dev": true,
+          "requires": {
+            "strict-uri-encode": "^1.0.0"
+          }
+        }
+      }
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "html-comment-regex": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
+      "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
+      "dev": true
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
+      }
+    },
+    "http-parser-js": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
+      "dev": true
+    },
+    "http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+      "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+      "dev": true,
+      "requires": {
+        "http-proxy": "^1.16.2",
+        "is-glob": "^3.1.0",
+        "lodash": "^4.17.2",
+        "micromatch": "^2.3.11"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "https-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+      "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+      "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
+    },
+    "image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+      "dev": true,
+      "optional": true
+    },
+    "imports-loader": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
+      "integrity": "sha1-rnRlMDHVnjezwvslRKxhrq41MKY=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "0.2.x",
+        "source-map": "0.1.x"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz",
+      "integrity": "sha1-geM3ToNhvq/y2XAWIG01nQsy+k0=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^1.0.1",
+        "figures": "^1.3.5",
+        "lodash": "^3.3.1",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "interpret": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
+      "integrity": "sha1-/s16GOfOXKar+5U+H4YhOknxYls=",
+      "dev": true
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true
+    },
+    "is-absolute-url": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-arguments": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^1.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-core-module": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+      "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
+      "dev": true
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
+      "requires": {
+        "is-primitive": "^2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.20.5",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
+      "integrity": "sha512-VTPuvvGQtxvCeghwspQu1rBgjYUT6FGxPlvFKbYuFtgc4ADsX3U5ihZOYN0qyU6u+d4X9xXb0IT5O6QpXKt87A==",
+      "dev": true,
+      "requires": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-svg": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+      "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+      "dev": true,
+      "requires": {
+        "html-comment-regex": "^1.1.0"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isbinaryfile": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+      "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
+      "dev": true,
+      "requires": {
+        "buffer-alloc": "^1.2.0"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "js-base64": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "js-yaml": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+      "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^2.6.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jsdom": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-8.5.0.tgz",
+      "integrity": "sha1-1Nj12/J2hjW2KmKCO5R89wcevJg=",
+      "dev": true,
+      "requires": {
+        "abab": "^1.0.0",
+        "acorn": "^2.4.0",
+        "acorn-globals": "^1.0.4",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.0 < 0.4.0",
+        "cssstyle": ">= 0.2.34 < 0.3.0",
+        "escodegen": "^1.6.1",
+        "iconv-lite": "^0.4.13",
+        "nwmatcher": ">= 1.3.7 < 2.0.0",
+        "parse5": "^1.5.1",
+        "request": "^2.55.0",
+        "sax": "^1.1.4",
+        "symbol-tree": ">= 3.1.0 < 4.0.0",
+        "tough-cookie": "^2.2.0",
+        "webidl-conversions": "^3.0.1",
+        "whatwg-url": "^2.0.1",
+        "xml-name-validator": ">= 2.0.1 < 3.0.0"
+      }
+    },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "dev": true
+    },
+    "json-loader": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
+      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "karma": {
+      "version": "0.13.22",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-0.13.22.tgz",
+      "integrity": "sha1-B3ULG9Bj1+fnuRvNLmNU2PKqh0Q=",
+      "dev": true,
+      "requires": {
+        "batch": "^0.5.3",
+        "bluebird": "^2.9.27",
+        "body-parser": "^1.12.4",
+        "chokidar": "^1.4.1",
+        "colors": "^1.1.0",
+        "connect": "^3.3.5",
+        "core-js": "^2.1.0",
+        "di": "^0.0.1",
+        "dom-serialize": "^2.2.0",
+        "expand-braces": "^0.1.1",
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.2",
+        "http-proxy": "^1.13.0",
+        "isbinaryfile": "^3.0.0",
+        "lodash": "^3.8.0",
+        "log4js": "^0.6.31",
+        "mime": "^1.3.4",
+        "minimatch": "^3.0.0",
+        "optimist": "^0.6.1",
+        "rimraf": "^2.3.3",
+        "socket.io": "^1.4.5",
+        "source-map": "^0.5.3",
+        "useragent": "^2.1.6"
+      }
+    },
+    "karma-chrome-launcher": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.2.3.tgz",
+      "integrity": "sha1-TG1wDRY6nTTGGO/YeRi+SeekqMk=",
+      "dev": true,
+      "requires": {
+        "fs-access": "^1.0.0",
+        "which": "^1.2.1"
+      }
+    },
+    "karma-expect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/karma-expect/-/karma-expect-1.1.3.tgz",
+      "integrity": "sha1-xrClb/GJA9sRr08JjMbnzxmM4nU=",
+      "dev": true,
+      "requires": {
+        "expect.js": "^0.3.1"
+      }
+    },
+    "karma-jsdom-launcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/karma-jsdom-launcher/-/karma-jsdom-launcher-3.0.0.tgz",
+      "integrity": "sha1-ExKHvm6LwSX2VVg5lUEfg0gMmjk=",
+      "dev": true,
+      "requires": {
+        "jsdom": "^8.0.0"
+      }
+    },
+    "karma-mocha": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-0.2.2.tgz",
+      "integrity": "sha1-OI7ZF9oV3LGW0bkVwZNO+AMZP44=",
+      "dev": true
+    },
+    "karma-mocha-reporter": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/karma-mocha-reporter/-/karma-mocha-reporter-2.2.5.tgz",
+      "integrity": "sha1-FRIAlejtgZGG5HoLAS8810GJVWA=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "karma-sauce-launcher": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.3.1.tgz",
+      "integrity": "sha1-+kH2r9GtbLdhCIXag8vJkhpNM0w=",
+      "dev": true,
+      "requires": {
+        "q": "^1.4.1",
+        "sauce-connect-launcher": "^0.13.0",
+        "saucelabs": "^1.0.1",
+        "wd": "^0.3.4"
+      }
+    },
+    "karma-sinon": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/karma-sinon/-/karma-sinon-1.0.5.tgz",
+      "integrity": "sha1-TjRD8oMP3s/2JNN0cWPxIX2qKpo=",
+      "dev": true
+    },
+    "karma-sourcemap-loader": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.8.tgz",
+      "integrity": "sha512-zorxyAakYZuBcHRJE+vbrK2o2JXLFWK8VVjiT/6P+ltLBUGUvqTEkUiQ119MGdOrK7mrmxXHZF1/pfT6GgIZ6g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "karma-webpack": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-1.8.1.tgz",
+      "integrity": "sha1-OdX9Lt7qPMPvW0BZibN9Ww5qO04=",
+      "dev": true,
+      "requires": {
+        "async": "~0.9.0",
+        "loader-utils": "^0.2.5",
+        "lodash": "^3.8.0",
+        "source-map": "^0.1.41",
+        "webpack-dev-middleware": "^1.0.11"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
+    "keycode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
+      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true
+    },
+    "lazystream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
+      "integrity": "sha1-GyXWPHcqTCDwpe0KnXf0hLbhaSA=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~1.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
+    "less": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/less/-/less-2.7.3.tgz",
+      "integrity": "sha512-KPdIJKWcEAb02TuJtaLrhue0krtRLoRoo7x6BNJIBelO00t/CCdJQUnHW5V34OnHMWzIktSalJxRO+FvytQlCQ==",
+      "dev": true,
+      "requires": {
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "mime": "^1.2.11",
+        "mkdirp": "^0.5.0",
+        "promise": "^7.1.1",
+        "request": "2.81.0",
+        "source-map": "^0.5.3"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
+          }
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
+          }
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "dev": true,
+          "optional": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "dev": true,
+          "optional": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true,
+          "optional": true
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        }
+      }
+    },
+    "less-loader": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-2.2.3.tgz",
+      "integrity": "sha1-ttj4E5yEk98J2ZKpOgBzSwj4RSg=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^0.2.5"
+      }
+    },
+    "less2sass": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/less2sass/-/less2sass-1.0.3.tgz",
+      "integrity": "sha1-v3bQXHMm0Vo4NUYQRTbUnBpbu2I=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.9.0",
+        "mkdirp": "^0.5.1",
+        "win-fork": "^1.1.1"
+      }
+    },
+    "levn": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+      "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.0",
+        "type-check": "~0.3.1"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      }
+    },
+    "loader-utils": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+      "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+      "dev": true,
+      "requires": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+      "dev": true
+    },
+    "lodash-compat": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/lodash-compat/-/lodash-compat-3.10.2.tgz",
+      "integrity": "sha1-xpQBKKnTD46QLNLPmf0Muk7PwYM=",
+      "dev": true
+    },
+    "lodash._arraycopy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+      "dev": true
+    },
+    "lodash._arrayeach": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+      "dev": true
+    },
+    "lodash._arraymap": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+      "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._baseclone": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "dev": true,
+      "requires": {
+        "lodash._arraycopy": "^3.0.0",
+        "lodash._arrayeach": "^3.0.0",
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basefor": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basedifference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+      "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
+      "dev": true,
+      "requires": {
+        "lodash._baseindexof": "^3.0.0",
+        "lodash._cacheindexof": "^3.0.0",
+        "lodash._createcache": "^3.0.0"
+      }
+    },
+    "lodash._baseflatten": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+      "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
+      "dev": true,
+      "requires": {
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+      "dev": true
+    },
+    "lodash._baseindexof": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+      "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+      "dev": true
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "dev": true
+    },
+    "lodash._cacheindexof": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+      "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+      "dev": true
+    },
+    "lodash._createassigner": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+      "dev": true,
+      "requires": {
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
+      }
+    },
+    "lodash._createcache": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0"
+      }
+    },
+    "lodash._createcompounder": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
+      "integrity": "sha1-XdLLVTctbnDg4jkvsjBNZjEJEHU=",
+      "dev": true,
+      "requires": {
+        "lodash.deburr": "^3.0.0",
+        "lodash.words": "^3.0.0"
+      }
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash._pickbyarray": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+      "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU=",
+      "dev": true
+    },
+    "lodash._pickbycallback": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+      "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
+      "dev": true,
+      "requires": {
+        "lodash._basefor": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
+      }
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+      "dev": true
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
+      "integrity": "sha1-kyyLh/ikN3iXxnGXUzKC+Xrqwpg=",
+      "dev": true,
+      "requires": {
+        "lodash._createcompounder": "^3.0.0"
+      }
+    },
+    "lodash.clonedeep": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "dev": true,
+      "requires": {
+        "lodash._baseclone": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0"
+      }
+    },
+    "lodash.deburr": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz",
+      "integrity": "sha1-baj1QzSjZqfPTEx2742Aqhs2XtU=",
+      "dev": true,
+      "requires": {
+        "lodash._root": "^3.0.0"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+      "dev": true,
+      "requires": {
+        "lodash._basefor": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
+      }
+    },
+    "lodash.istypedarray": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lodash.keysin": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+      "dev": true,
+      "requires": {
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+      "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
+      "dev": true,
+      "requires": {
+        "lodash._arraycopy": "^3.0.0",
+        "lodash._arrayeach": "^3.0.0",
+        "lodash._createassigner": "^3.0.0",
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.isplainobject": "^3.0.0",
+        "lodash.istypedarray": "^3.0.0",
+        "lodash.keys": "^3.0.0",
+        "lodash.keysin": "^3.0.0",
+        "lodash.toplainobject": "^3.0.0"
+      }
+    },
+    "lodash.omit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+      "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
+      "dev": true,
+      "requires": {
+        "lodash._arraymap": "^3.0.0",
+        "lodash._basedifference": "^3.0.0",
+        "lodash._baseflatten": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._pickbyarray": "^3.0.0",
+        "lodash._pickbycallback": "^3.0.0",
+        "lodash.keysin": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
+      }
+    },
+    "lodash.pickby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
+      "dev": true
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
+    },
+    "lodash.toplainobject": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+      "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
+      }
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "lodash.words": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz",
+      "integrity": "sha1-TiqGSbwIdFsXxpWxo86P7llmI7M=",
+      "dev": true,
+      "requires": {
+        "lodash._root": "^3.0.0"
+      }
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "log4js": {
+      "version": "0.6.38",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
+      "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~1.0.2",
+        "semver": "~4.3.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "dev": true
+    },
+    "math-expression-evaluator": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.3.7.tgz",
+      "integrity": "sha512-nrbaifCl42w37hYd6oRLvoymFK42tWB+WQTMFtksDGQMi5GvlJwnz/CsS30FFAISFLtX+A0csJ0xLiuuyyec7w==",
+      "dev": true
+    },
+    "math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "dev": true
+    },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "memory-fs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "dev": true,
+      "requires": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
+      }
+    },
+    "miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        }
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.47.0"
+      }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true,
+          "requires": {
+            "inherits": "2",
+            "minimatch": "0.3"
+          }
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+          "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+          "dev": true
+        }
+      }
+    },
+    "modify-babel-preset": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/modify-babel-preset/-/modify-babel-preset-1.2.0.tgz",
+      "integrity": "sha1-0bfIwkiW4Z28SEc0chPmtxRNG8c=",
+      "dev": true,
+      "requires": {
+        "require-relative": "^0.8.7"
+      }
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mt-changelog": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/mt-changelog/-/mt-changelog-0.6.2.tgz",
+      "integrity": "sha1-AEjl08afaju/oVVGWzjw3fPAqDI=",
+      "dev": true,
+      "requires": {
+        "child-process-promise": "^1.0.2",
+        "colors": "^1.0.3",
+        "commander": "^2.8.1",
+        "fs-promise": "^0.3.1",
+        "promise": "^7.0.4",
+        "semver": "^5.0.0"
+      }
+    },
+    "mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "nested-error-stacks": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
+      "integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.1"
+      }
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "node-int64": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz",
+      "integrity": "sha1-LW5rLs5d6FiLQ9iNG8QbJs0fqE0=",
+      "dev": true
+    },
+    "node-libs-browser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-1.1.1.tgz",
+      "integrity": "sha1-KjgkOr7dff/NB6l8mspWaJdab+o=",
+      "dev": true,
+      "requires": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "0.0.1",
+        "os-browserify": "^0.2.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.3.1",
+        "string_decoder": "^0.10.25",
+        "timers-browserify": "^1.4.2",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
+    },
+    "normalize-url": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
+      }
+    },
+    "null-check": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+      "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
+      "dev": true
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "nwmatcher": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-component": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
+      "requires": {
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "open": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
+      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.6.0.tgz",
+      "integrity": "sha1-tj7Lvw4xX61LyYJ7Rdx7pFKE/LY=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~1.0.6",
+        "levn": "~0.2.5",
+        "prelude-ls": "~1.1.1",
+        "type-check": "~0.3.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
+      "dev": true
+    },
+    "original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "dev": true,
+      "requires": {
+        "url-parse": "^1.4.3"
+      }
+    },
+    "os-browserify": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+      "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "^1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "output-file-sync": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.4",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "dev": true
+    },
+    "parse-asn1": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+      "dev": true,
+      "requires": {
+        "asn1.js": "^5.2.0",
+        "browserify-aes": "^1.0.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
+      "requires": {
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "parse5": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+      "dev": true
+    },
+    "parsejson": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
+      "dev": true,
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseqs": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "dev": true,
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseuri": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "dev": true,
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "pbkdf2": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "dev": true,
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "pbkdf2-compat": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
+      "integrity": "sha1-tuDI+plJTZTgURV1gCpZpcFC8og=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0"
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "postcss": {
+      "version": "5.2.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "js-base64": "^2.1.9",
+        "source-map": "^0.5.6",
+        "supports-color": "^3.2.3"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "postcss-calc": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+      "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.2",
+        "postcss-message-helpers": "^2.0.0",
+        "reduce-css-calc": "^1.2.6"
+      }
+    },
+    "postcss-colormin": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+      "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+      "dev": true,
+      "requires": {
+        "colormin": "^1.0.5",
+        "postcss": "^5.0.13",
+        "postcss-value-parser": "^3.2.3"
+      }
+    },
+    "postcss-convert-values": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+      "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.11",
+        "postcss-value-parser": "^3.1.2"
+      }
+    },
+    "postcss-discard-comments": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+      "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.14"
+      }
+    },
+    "postcss-discard-duplicates": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+      "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4"
+      }
+    },
+    "postcss-discard-empty": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+      "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.14"
+      }
+    },
+    "postcss-discard-overridden": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+      "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.16"
+      }
+    },
+    "postcss-discard-unused": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+      "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.14",
+        "uniqs": "^2.0.0"
+      }
+    },
+    "postcss-filter-plugins": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
+      "integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4"
+      }
+    },
+    "postcss-merge-idents": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+      "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1",
+        "postcss": "^5.0.10",
+        "postcss-value-parser": "^3.1.1"
+      }
+    },
+    "postcss-merge-longhand": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+      "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4"
+      }
+    },
+    "postcss-merge-rules": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+      "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^1.5.2",
+        "caniuse-api": "^1.5.2",
+        "postcss": "^5.0.4",
+        "postcss-selector-parser": "^2.2.2",
+        "vendors": "^1.0.0"
+      }
+    },
+    "postcss-message-helpers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+      "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
+      "dev": true
+    },
+    "postcss-minify-font-values": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+      "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
+      }
+    },
+    "postcss-minify-gradients": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+      "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.12",
+        "postcss-value-parser": "^3.3.0"
+      }
+    },
+    "postcss-minify-params": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+      "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.1",
+        "postcss": "^5.0.2",
+        "postcss-value-parser": "^3.0.2",
+        "uniqs": "^2.0.0"
+      }
+    },
+    "postcss-minify-selectors": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+      "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.2",
+        "has": "^1.0.1",
+        "postcss": "^5.0.14",
+        "postcss-selector-parser": "^2.0.0"
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
+      "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
+      "dev": true,
+      "requires": {
+        "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+      "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "css-selector-tokenizer": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz",
+          "integrity": "sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "fastparse": "^1.1.2"
+          }
+        },
+        "cssesc": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+      "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "css-selector-tokenizer": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz",
+          "integrity": "sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "fastparse": "^1.1.2"
+          }
+        },
+        "cssesc": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-values": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+      "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+      "dev": true,
+      "requires": {
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-normalize-charset": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+      "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.5"
+      }
+    },
+    "postcss-normalize-url": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+      "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^1.4.0",
+        "postcss": "^5.0.14",
+        "postcss-value-parser": "^3.2.3"
+      }
+    },
+    "postcss-ordered-values": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+      "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.1"
+      }
+    },
+    "postcss-reduce-idents": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+      "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
+      }
+    },
+    "postcss-reduce-initial": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+      "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4"
+      }
+    },
+    "postcss-reduce-transforms": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+      "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1",
+        "postcss": "^5.0.8",
+        "postcss-value-parser": "^3.0.1"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+      "dev": true,
+      "requires": {
+        "flatten": "^1.0.2",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
+    },
+    "postcss-svgo": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+      "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+      "dev": true,
+      "requires": {
+        "is-svg": "^2.0.0",
+        "postcss": "^5.0.14",
+        "postcss-value-parser": "^3.2.3",
+        "svgo": "^0.7.0"
+      }
+    },
+    "postcss-unique-selectors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+      "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "dev": true
+    },
+    "postcss-zindex": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+      "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "prismjs": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
+      "dev": true,
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "dev": true,
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      }
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
+    },
+    "public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        }
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "dev": true
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "dev": true
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.18.0.tgz",
+      "integrity": "sha1-xuPF1LmrH3kGcn/e6wORUqhdTbM=",
+      "dev": true
+    },
+    "randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "dev": true,
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "raw-loader": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
+      "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
+      "dev": true
+    },
+    "react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "react-bootstrap": {
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.29.5.tgz",
+      "integrity": "sha1-DG96fQaDSw24WhjM3cBLEpxfIFg=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^5.8.38",
+        "classnames": "^2.2.3",
+        "dom-helpers": "^2.4.0",
+        "invariant": "^2.2.1",
+        "keycode": "^2.1.1",
+        "lodash-compat": "^3.10.2",
+        "react-overlays": "^0.6.3",
+        "react-prop-types": "^0.3.0",
+        "uncontrollable": "^3.2.3",
+        "warning": "^2.1.0"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
+          "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
+          "dev": true,
+          "requires": {
+            "core-js": "^1.0.0"
+          }
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        },
+        "uncontrollable": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-3.3.1.tgz",
+          "integrity": "sha1-4jtALnpMabGFP7S0PONLZIDGW28=",
+          "dev": true,
+          "requires": {
+            "invariant": "^2.1.0"
+          }
+        }
+      }
+    },
+    "react-dom": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.7.0.tgz",
+      "integrity": "sha512-mpjXqC2t1FuYsILOLCj0kg6pbg460byZkVA/80VtDmKU/pYmoTdHOtaMcTRIDiyXLz4sIur0cQ04nOC6iGndJg==",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0",
+        "prop-types": "^15.5.10"
+      }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-overlays": {
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.6.12.tgz",
+      "integrity": "sha1-oHnHUMxCnX20x0dKlbS1QDPiVcM=",
+      "dev": true,
+      "requires": {
+        "classnames": "^2.2.5",
+        "dom-helpers": "^3.2.0",
+        "react-prop-types": "^0.4.0",
+        "warning": "^3.0.0"
+      },
+      "dependencies": {
+        "dom-helpers": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "react-prop-types": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
+          "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
+          "dev": true,
+          "requires": {
+            "warning": "^3.0.0"
+          }
+        },
+        "warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
+    "react-prop-types": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.3.2.tgz",
+      "integrity": "sha1-4nY6xvOoAZnYmBw2R8RLBVTJe38=",
+      "dev": true,
+      "requires": {
+        "warning": "^2.0.0"
+      }
+    },
+    "react-router": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.0.1.tgz",
+      "integrity": "sha1-JczdjYiJhXlFUhoh9c1n3cjR5dg=",
+      "dev": true,
+      "requires": {
+        "history": "^2.0.0",
+        "invariant": "^2.0.0",
+        "warning": "^2.0.0"
+      }
+    },
+    "react-test-renderer": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.8.6",
+        "scheduler": "^0.19.1"
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        }
+      }
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "mute-stream": "0.0.5"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
+    },
+    "reduce-css-calc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^0.4.2",
+        "math-expression-evaluator": "^1.2.14",
+        "reduce-function-call": "^1.0.1"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
+        }
+      }
+    },
+    "reduce-function-call": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.3.tgz",
+      "integrity": "sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "^0.1.3"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "regexpu-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "release-script": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/release-script/-/release-script-1.0.2.tgz",
+      "integrity": "sha1-OfEap00mscoCXBu53XAtZqXlppA=",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.2",
+        "github-url-to-object": "^2.1.0",
+        "request": "^2.60.0",
+        "semver": "^5.0.0",
+        "shelljs": "^0.5.1",
+        "yargs": "^3.15.0"
+      },
+      "dependencies": {
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
+          }
+        }
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        }
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "requires": {
+        "align-text": "^0.1.1"
+      }
+    },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0"
+      }
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "dev": true
+    },
+    "sauce-connect-launcher": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.13.0.tgz",
+      "integrity": "sha1-JdffnaFqXtHKoT30JMtXywttWiI=",
+      "dev": true,
+      "requires": {
+        "adm-zip": "~0.4.3",
+        "async": "1.4.0",
+        "lodash": "3.10.1",
+        "rimraf": "2.4.3"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz",
+          "integrity": "sha1-Nfhvg8WeBCHQmc2akdgnj7V4wA0=",
+          "dev": true
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+          "integrity": "sha1-5bUclDekxYKtuVXp8oz42UXicq8=",
+          "dev": true,
+          "requires": {
+            "glob": "^5.0.14"
+          }
+        }
+      }
+    },
+    "saucelabs": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.5.0.tgz",
+      "integrity": "sha512-jlX3FGdWvYf4Q3LFfFWS1QvPg3IGCGWxIc8QBFdPTbpTJnt/v17FHXYVAn7C8sHf1yUXo2c7yIM0isDryfYtHQ==",
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "^2.2.1"
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "scriptjs": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
+      "integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg==",
+      "dev": true
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "dev": true,
+      "optional": true
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+          "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+          "dev": true,
+          "requires": {
+            "mime-types": "~2.1.24",
+            "negotiator": "0.6.2"
+          }
+        },
+        "batch": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+          "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "negotiator": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+          "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "dev": true
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "shelljs": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+      "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "sinon": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": ">=0.10.3 <1"
+      }
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      }
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "socket.io": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz",
+      "integrity": "sha1-L37O3DORvy1cc+KR/iM+bjTU3QA=",
+      "dev": true,
+      "requires": {
+        "debug": "2.3.3",
+        "engine.io": "~1.8.4",
+        "has-binary": "0.1.7",
+        "object-assign": "4.1.0",
+        "socket.io-adapter": "0.5.0",
+        "socket.io-client": "1.7.4",
+        "socket.io-parser": "2.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+          "dev": true
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
+      "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
+      "dev": true,
+      "requires": {
+        "debug": "2.3.3",
+        "socket.io-parser": "2.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        }
+      }
+    },
+    "socket.io-client": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz",
+      "integrity": "sha1-7J+CA1btme9tNX8HVtZIcXvdQoE=",
+      "dev": true,
+      "requires": {
+        "backo2": "1.0.2",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "2.3.3",
+        "engine.io-client": "~1.8.4",
+        "has-binary": "0.1.7",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "2.3.1",
+        "to-array": "0.1.4"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+      "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.1.2",
+        "debug": "2.2.0",
+        "isarray": "0.0.1",
+        "json3": "3.3.2"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        }
+      }
+    },
+    "sockjs": {
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.21.tgz",
+      "integrity": "sha512-DhbPFGpxjc6Z3I+uX07Id5ZO2XwYsWOrYjaSeieES78cq+JaJvVe5q/m1uvjIQhXinhIeCFRH6JgXe+mvVMyXw==",
+      "dev": true,
+      "requires": {
+        "faye-websocket": "^0.11.3",
+        "uuid": "^3.4.0",
+        "websocket-driver": "^0.7.4"
+      }
+    },
+    "sockjs-client": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.1.tgz",
+      "integrity": "sha512-VnVAb663fosipI/m6pqRXakEOw7nvd7TUgdr3PlR/8V2I95QIdwT8L4nMxhyU8SmDBHYXU1TOElaKOmKLfYzeQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.6",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "^0.11.3",
+        "inherits": "^2.0.4",
+        "json3": "^3.3.3",
+        "url-parse": "^1.5.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "json3": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+          "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
+    "source-list-map": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+      "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.5.6"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
+    },
+    "stream-browserify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "stream-cache": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz",
+      "integrity": "sha1-GsWtaDJCjKVWZ9ve45Xa1ObbEY8=",
+      "dev": true
+    },
+    "stream-http": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+      "dev": true,
+      "requires": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "style-loader": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.2.tgz",
+      "integrity": "sha1-dFMzhM9pjHEEx5URULSXF63C87s=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.2"
+      },
+      "dependencies": {
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "dev": true
+        },
+        "emojis-list": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "dev": true
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        }
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "svgo": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+      "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+      "dev": true,
+      "requires": {
+        "coa": "~1.0.1",
+        "colors": "~1.1.2",
+        "csso": "~2.3.1",
+        "js-yaml": "~3.7.0",
+        "mkdirp": "~0.5.1",
+        "sax": "~1.2.1",
+        "whet.extend": "~0.9.9"
+      }
+    },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
+    "tapable": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+      "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
+      "dev": true
+    },
+    "tar-stream": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
+      "integrity": "sha1-vpIYwTDCACnhB7D5Z/sj3gV50Tw=",
+      "dev": true,
+      "requires": {
+        "bl": "^0.9.0",
+        "end-of-stream": "^1.0.0",
+        "readable-stream": "~1.0.33",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "teaspoon": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/teaspoon/-/teaspoon-6.6.0.tgz",
+      "integrity": "sha1-AiFQy5gz2OdYlcvGc4E8vGxZTUs=",
+      "dev": true,
+      "requires": {
+        "bill": "^3.2.6",
+        "dom-helpers": "^2.4.0",
+        "invariant": "^2.2.0",
+        "lodash": "^3.10.1",
+        "promise": "^7.1.1",
+        "react-test-renderer": "^15.5.4 || ^16.0.0",
+        "warning": "^2.1.0"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "time-stamp": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.2.0.tgz",
+      "integrity": "sha512-zxke8goJQpBeEgD82CXABeMh0LSJcj7CXEd0OHOg45HgcofF7pxNwZm9+RknpxpDhwN4gFpySkApKfFYfRQnUA==",
+      "dev": true
+    },
+    "timers-browserify": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+      "dev": true,
+      "requires": {
+        "process": "~0.11.0"
+      }
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "dev": true,
+      "optional": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "to-array": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+      "dev": true
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        }
+      }
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "tty-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.28",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.6.tgz",
+      "integrity": "sha512-rRprLwl8RVaS+Qvx3Wh5hPfPBn9++G6xkGlUupya0s5aDmNjI7z3lnRLB3u7sN4OmbB0pWgzhM9BEJyiWAwtAA==",
+      "dev": true,
+      "optional": true
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true
+    },
+    "ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
+      "dev": true
+    },
+    "uncontrollable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-4.1.0.tgz",
+      "integrity": "sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=",
+      "requires": {
+        "invariant": "^2.1.0"
+      }
+    },
+    "underscore.string": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz",
+      "integrity": "sha1-Rhe4waJQz25QZPu7Nj0PqWzxRVI=",
+      "dev": true
+    },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "uniqs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+      "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+      "dev": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
+      }
+    },
+    "url-loader": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
+      "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.2",
+        "mime": "1.3.x"
+      },
+      "dependencies": {
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "dev": true
+        },
+        "emojis-list": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "dev": true
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "mime": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+          "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
+          "dev": true
+        }
+      }
+    },
+    "url-parse": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+      "dev": true
+    },
+    "useragent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.x",
+        "tmp": "0.0.x"
+      }
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
+    },
+    "v8flags": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "dev": true,
+      "requires": {
+        "user-home": "^1.1.1"
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vargs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
+      "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8=",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
+    "vendors": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.4.tgz",
+      "integrity": "sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "vm-browserify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+      "dev": true,
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
+    "void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "dev": true
+    },
+    "warning": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
+      "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE=",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "watchpack": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+      "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
+      "dev": true,
+      "requires": {
+        "async": "^0.9.0",
+        "chokidar": "^1.0.0",
+        "graceful-fs": "^4.1.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        }
+      }
+    },
+    "wd": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/wd/-/wd-0.3.12.tgz",
+      "integrity": "sha1-P7Tx11n4yF3eU5PRczT/4D6bsyk=",
+      "dev": true,
+      "requires": {
+        "archiver": "~0.14.0",
+        "async": "~1.0.0",
+        "lodash": "~3.9.3",
+        "q": "~1.4.1",
+        "request": "~2.55.0",
+        "underscore.string": "~3.0.3",
+        "vargs": "~0.1.0"
+      },
+      "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+          "dev": true
+        },
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+          "dev": true
+        },
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+          "integrity": "sha1-t7Zc5r8UE4hlOc/VM/CzDv+pz4g=",
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+          "dev": true,
+          "requires": {
+            "delayed-stream": "0.0.5"
+          }
+        },
+        "delayed-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+          "dev": true
+        },
+        "form-data": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
+          "dev": true,
+          "requires": {
+            "async": "~0.9.0",
+            "combined-stream": "~0.0.4",
+            "mime-types": "~2.0.3"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+              "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+              "dev": true
+            }
+          }
+        },
+        "har-validator": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+          "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
+          "dev": true,
+          "requires": {
+            "bluebird": "^2.9.30",
+            "chalk": "^1.0.0",
+            "commander": "^2.8.1",
+            "is-my-json-valid": "^2.12.0"
+          }
+        },
+        "http-signature": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+          "dev": true,
+          "requires": {
+            "asn1": "0.1.11",
+            "assert-plus": "^0.1.5",
+            "ctype": "0.5.3"
+          }
+        },
+        "lodash": {
+          "version": "3.9.3",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
+          "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI=",
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.12.0"
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+          "integrity": "sha1-fb6uRPbKRU4fFoRR1jB0ZzWBPOM=",
+          "dev": true
+        },
+        "q": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+          "dev": true
+        },
+        "qs": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
+          "integrity": "sha1-9854jld33wtQENp/fE5zujJHD1o=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.55.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+          "integrity": "sha1-11wc32eddrsQD5v/4f5VG1wk6T0=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.5.0",
+            "bl": "~0.9.0",
+            "caseless": "~0.9.0",
+            "combined-stream": "~0.0.5",
+            "forever-agent": "~0.6.0",
+            "form-data": "~0.2.0",
+            "har-validator": "^1.4.0",
+            "hawk": "~2.3.0",
+            "http-signature": "~0.10.0",
+            "isstream": "~0.1.1",
+            "json-stringify-safe": "~5.0.0",
+            "mime-types": "~2.0.1",
+            "node-uuid": "~1.4.0",
+            "oauth-sign": "~0.6.0",
+            "qs": "~2.4.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": ">=0.12.0",
+            "tunnel-agent": "~0.4.0"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "dev": true
+        }
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
+    "webpack": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz",
+      "integrity": "sha1-T/MfU9sDM55VFkqdRo7gMklo/pg=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.0",
+        "async": "^1.3.0",
+        "clone": "^1.0.2",
+        "enhanced-resolve": "~0.9.0",
+        "interpret": "^0.6.4",
+        "loader-utils": "^0.2.11",
+        "memory-fs": "~0.3.0",
+        "mkdirp": "~0.5.0",
+        "node-libs-browser": "^0.7.0",
+        "optimist": "~0.6.0",
+        "supports-color": "^3.1.0",
+        "tapable": "~0.1.8",
+        "uglify-js": "~2.7.3",
+        "watchpack": "^0.2.1",
+        "webpack-core": "~0.6.9"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        },
+        "browserify-aes": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
+          "integrity": "sha1-BnFJtmjfMcS1hTPgLQHoBthgjiw=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          }
+        },
+        "crypto-browserify": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
+          "integrity": "sha1-ufx1u0oO1h3PHNXa6W6zDJw+UGw=",
+          "dev": true,
+          "requires": {
+            "browserify-aes": "0.4.0",
+            "pbkdf2-compat": "2.0.1",
+            "ripemd160": "0.2.0",
+            "sha.js": "2.2.6"
+          }
+        },
+        "memory-fs": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+          "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "node-libs-browser": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
+          "integrity": "sha1-PicsCBnjCJNeJmdECNevDhSRuDs=",
+          "dev": true,
+          "requires": {
+            "assert": "^1.1.1",
+            "browserify-zlib": "^0.1.4",
+            "buffer": "^4.9.0",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "^1.0.0",
+            "crypto-browserify": "3.3.0",
+            "domain-browser": "^1.1.1",
+            "events": "^1.0.0",
+            "https-browserify": "0.0.1",
+            "os-browserify": "^0.2.0",
+            "path-browserify": "0.0.0",
+            "process": "^0.11.0",
+            "punycode": "^1.2.4",
+            "querystring-es3": "^0.2.0",
+            "readable-stream": "^2.0.5",
+            "stream-browserify": "^2.0.1",
+            "stream-http": "^2.3.1",
+            "string_decoder": "^0.10.25",
+            "timers-browserify": "^2.0.2",
+            "tty-browserify": "0.0.0",
+            "url": "^0.11.0",
+            "util": "^0.10.3",
+            "vm-browserify": "0.0.4"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "ripemd160": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
+          "integrity": "sha1-K/GYveFnys+lHAqSjoS2i74XH84=",
+          "dev": true
+        },
+        "sha.js": {
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
+          "integrity": "sha1-F93t3F9yL7ZlAWWIlUYZd4ZzFbo=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        },
+        "timers-browserify": {
+          "version": "2.0.12",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+          "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
+          "dev": true,
+          "requires": {
+            "setimmediate": "^1.0.4"
+          }
+        },
+        "uglify-js": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+          "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
+          "dev": true,
+          "requires": {
+            "async": "~0.2.6",
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+              "dev": true
+            }
+          }
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
+            "window-size": "0.1.0"
+          }
+        }
+      }
+    },
+    "webpack-core": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
+      "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
+      "dev": true,
+      "requires": {
+        "source-list-map": "~0.1.7",
+        "source-map": "~0.4.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
+    "webpack-dev-middleware": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
+      "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+      "dev": true,
+      "requires": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.5.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0"
+      }
+    },
+    "webpack-dev-server": {
+      "version": "1.16.5",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.5.tgz",
+      "integrity": "sha1-DL1fLSrI1OWTqs1clwLnu9XlmJI=",
+      "dev": true,
+      "requires": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "open": "0.0.5",
+        "optimist": "~0.6.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.10.2"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "webpack-sources": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
+      "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
+      "dev": true,
+      "requires": {
+        "source-list-map": "~0.1.7",
+        "source-map": "~0.5.3"
+      }
+    },
+    "websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dev": true,
+      "requires": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-2.0.1.tgz",
+      "integrity": "sha1-U5ayBD8CDub3BNnEXqhRnnJN5lk=",
+      "dev": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "whet.extend": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+      "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "dev": true
+    },
+    "win-fork": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-fork/-/win-fork-1.1.1.tgz",
+      "integrity": "sha1-j1jgZW/KAK3IyGoriePNLWotXl4=",
+      "dev": true
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "dev": true
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "ws": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+      "dev": true,
+      "requires": {
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
+      }
+    },
+    "wtf-8": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+      "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo=",
+      "dev": true
+    },
+    "xml-escape": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
+      "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+      "dev": true
+    },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
+      "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+      "dev": true,
+      "requires": {
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "lodash.assign": "^4.0.3",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.1",
+        "which-module": "^1.0.0",
+        "window-size": "^0.2.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^2.4.1"
+      },
+      "dependencies": {
+        "window-size": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+          "dev": true
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^3.0.0",
+        "lodash.assign": "^4.0.6"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        }
+      }
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+      "dev": true
+    },
+    "zip-stream": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.2.tgz",
+      "integrity": "sha1-Mty8UG0Nq00hNyYlvX66rDwv/1Y=",
+      "dev": true,
+      "requires": {
+        "compress-commons": "~0.2.0",
+        "lodash": "~3.2.0",
+        "readable-stream": "~1.0.26"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
+          "integrity": "sha1-S/UKMkP5rrC6xBpV09WZBnWkYvs=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-widgets",
-  "version": "3.4.5",
+  "version": "3.4.6-fork.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lacework/react-widgets-fork",
-  "version": "3.4.6-0",
+  "version": "3.4.6-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lacework/react-widgets-fork",
-  "version": "3.4.6-1",
+  "version": "3.4.6-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3164,26 +3164,6 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
-    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -3943,29 +3923,6 @@
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"
-      }
-    },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "dev": true,
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        }
       }
     },
     "figures": {
@@ -5124,12 +5081,6 @@
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
-    },
     "is-svg": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
@@ -5191,16 +5142,6 @@
       "dev": true,
       "requires": {
         "isarray": "1.0.0"
-      }
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -6712,16 +6653,6 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
-    },
     "node-int64": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz",
@@ -8149,15 +8080,15 @@
       }
     },
     "react-dom": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.7.0.tgz",
-      "integrity": "sha512-mpjXqC2t1FuYsILOLCj0kg6pbg460byZkVA/80VtDmKU/pYmoTdHOtaMcTRIDiyXLz4sIur0cQ04nOC6iGndJg==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.9",
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
       }
     },
     "react-is": {
@@ -10064,12 +9995,6 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
-      "dev": true
-    },
     "uglify-js": {
       "version": "3.13.6",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.6.tgz",
@@ -10893,12 +10818,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
-      "dev": true
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
       "dev": true
     },
     "whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lacework/react-widgets-fork",
-  "version": "3.4.6-fork.1.0",
+  "version": "3.4.6-0",
   "description": "An à la carte set of polished, extensible, and accessible inputs built for React",
   "main": "lib/index.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lacework/react-widgets-fork",
-  "version": "3.4.5",
+  "version": "3.4.6-fork.1.0",
   "description": "An à la carte set of polished, extensible, and accessible inputs built for React",
   "main": "lib/index.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -64,10 +64,12 @@
   },
   "dependencies": {
     "classnames": "^2.1.2",
+    "create-react-class": "^15.7.0",
     "date-arithmetic": "^3.0.0",
     "dom-helpers": "^2.2.4",
     "invariant": "^2.1.0",
     "loose-envify": "^1.2.0",
+    "prop-types": "^15.7.2",
     "uncontrollable": "^4.0.0",
     "warning": "^2.0.0"
   },
@@ -120,7 +122,7 @@
     "output-file-sync": "^1.1.1",
     "prismjs": "^1.2.0",
     "raw-loader": "^0.5.1",
-    "react": "^15.2.0",
+    "react": "^16.14.0",
     "react-bootstrap": "^0.29.0-0",
     "react-dom": "^15.2.0",
     "react-router": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-widgets",
+  "name": "@lacework/react-widgets-fork",
   "version": "3.4.5",
   "description": "An à la carte set of polished, extensible, and accessible inputs built for React",
   "main": "lib/index.js",
@@ -56,11 +56,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jquense/react-widgets"
+    "url": "https://github.com/lacework/react-widgets"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "dependencies": {
     "classnames": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "babel-core": "^6.7.6",
     "babel-eslint": "^6.0.2",
     "babel-loader": "^6.2.4",
+    "babel-plugin-react-require": "^3.1.3",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-jason": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lacework/react-widgets-fork",
-  "version": "3.4.6-0",
+  "version": "3.4.6-1",
   "description": "An à la carte set of polished, extensible, and accessible inputs built for React",
   "main": "lib/index.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lacework/react-widgets-fork",
-  "version": "3.4.6-1",
+  "version": "3.4.6-2",
   "description": "An à la carte set of polished, extensible, and accessible inputs built for React",
   "main": "lib/index.js",
   "author": {
@@ -56,8 +56,8 @@
     "url": "https://github.com/lacework/react-widgets"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": ">=16",
+    "react-dom": ">=16"
   },
   "dependencies": {
     "classnames": "^2.1.2",
@@ -122,7 +122,7 @@
     "raw-loader": "^0.5.1",
     "react": "^16.14.0",
     "react-bootstrap": "^0.29.0-0",
-    "react-dom": "^15.2.0",
+    "react-dom": "^16.14.0",
     "react-router": "2.0.1",
     "release-script": "^1.0.2",
     "rimraf": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -47,10 +47,7 @@
     "build:dist": "npm run clean:dist && npm run compile:dist & npm run compile:locale && npm run less && npm run assets:dist",
     "build": "npm run build:lib && npm run build:dist",
     "docs": "npm run clean:docs && webpack-dev-server --config ./build/docs.config.js --hot",
-    "dev": "webpack-dev-server --config ./build/dev.config.js --hot",
-    "release": "release",
-    "alpha": "release --preid alpha --tag next",
-    "beta": "release --preid beta --tag next"
+    "dev": "webpack-dev-server --config ./build/dev.config.js --hot"
   },
   "homepage": "http://jquense.github.io/react-widgets/docs/",
   "license": "MIT",

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -128,7 +128,7 @@ let Calendar = createReactClass({
 
   propTypes,
 
-  getInitialState() {
+  getInitialState(){
     return {
       selectedIndex: 0,
       view: this.props.initialView || 'month'
@@ -138,16 +138,16 @@ let Calendar = createReactClass({
   getDefaultProps() {
     return {
 
-      value: null,
-      min: new Date(1900, 0, 1),
-      max: new Date(2099, 11, 31),
-      currentDate: new Date(),
+      value:        null,
+      min:          new Date(1900, 0, 1),
+      max:          new Date(2099, 11, 31),
+      currentDate:  new Date(),
 
-      initialView: 'month',
-      finalView: 'century',
+      initialView:  'month',
+      finalView:    'century',
 
-      tabIndex: '0',
-      footer: false,
+      tabIndex:     '0',
+      footer:        false,
 
       ariaActiveDescendantKey: 'calendar',
       messages: msgs({})
@@ -159,19 +159,19 @@ let Calendar = createReactClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    var bottom = VIEW_OPTIONS.indexOf(nextProps.initialView)
-        , top = VIEW_OPTIONS.indexOf(nextProps.finalView)
-        , current = VIEW_OPTIONS.indexOf(this.state.view)
-        , view = this.state.view
-        , val = this.inRangeValue(nextProps.value);
+    var bottom  = VIEW_OPTIONS.indexOf(nextProps.initialView)
+      , top     = VIEW_OPTIONS.indexOf(nextProps.finalView)
+      , current = VIEW_OPTIONS.indexOf(this.state.view)
+      , view    = this.state.view
+      , val     = this.inRangeValue(nextProps.value);
 
-    if (current < bottom)
-      this.setState({view: view = nextProps.initialView})
+    if( current < bottom )
+      this.setState({ view: view = nextProps.initialView })
     else if (current > top)
-      this.setState({view: view = nextProps.finalView})
+      this.setState({ view: view = nextProps.finalView })
 
     //if the value changes reset views to the new one
-    if (!dates.eq(val, dateOrNull(this.props.value), VIEW_UNIT[view])) {
+    if ( !dates.eq(val, dateOrNull(this.props.value), VIEW_UNIT[view])) {
       this.changeCurrentDate(val, nextProps.currentDate)
     }
   },
@@ -179,7 +179,7 @@ let Calendar = createReactClass({
   render() {
 
     let {
-      className
+        className
       , value
       , footerFormat
       , disabled
@@ -195,99 +195,99 @@ let Calendar = createReactClass({
       , currentDate
     } = this.props
 
-    let {view, slideDirection, focused} = this.state;
+    let { view, slideDirection, focused } = this.state;
 
     var View = VIEW[view]
-        , unit = VIEW_UNIT[view]
-        , todaysDate = new Date()
-        , todayNotInRange = !dates.inRange(todaysDate, min, max, view)
+      , unit = VIEW_UNIT[view]
+      , todaysDate = new Date()
+      , todayNotInRange = !dates.inRange(todaysDate, min, max, view)
 
     unit = unit === 'day' ? 'date' : unit
 
     let viewID = instanceId(this, '_calendar')
-        , labelID = instanceId(this, '_calendar_label')
-        , key = view + '_' + dates[view](currentDate);
+      , labelID = instanceId(this, '_calendar_label')
+      , key = view + '_' + dates[view](currentDate);
 
     let elementProps = _.omitOwnProps(this)
-        , viewProps = _.pickProps(this.props, View)
+      , viewProps  = _.pickProps(this.props, View)
 
     let isDisabled = disabled || readOnly
 
     messages = msgs(this.props.messages)
 
     return (
-        <Widget
-            {...elementProps}
-            role='group'
-            focused={focused}
-            disabled={disabled}
-            readOnly={readOnly}
-            tabIndex={tabIndex || 0}
-            onBlur={this.handleBlur}
-            onFocus={this.handleFocus}
-            onKeyDown={this.handleKeyDown}
-            className={cn(className, 'rw-calendar')}
+      <Widget
+        {...elementProps}
+        role='group'
+        focused={focused}
+        disabled={disabled}
+        readOnly={readOnly}
+        tabIndex={tabIndex || 0}
+        onBlur={this.handleBlur}
+        onFocus={this.handleFocus}
+        onKeyDown={this.handleKeyDown}
+        className={cn(className, 'rw-calendar')}
+      >
+        <Header
+          label={this._label()}
+          labelId={labelID}
+          messages={messages}
+          upDisabled={  isDisabled || view === finalView}
+          prevDisabled={isDisabled || !dates.inRange(this.nextDate(dir.LEFT), min, max, view)}
+          nextDisabled={isDisabled || !dates.inRange(this.nextDate(dir.RIGHT), min, max, view)}
+          onViewChange={this.navigate.bind(null, dir.UP, null)}
+          onMoveLeft ={this.navigate.bind(null,  dir.LEFT, null)}
+          onMoveRight={this.navigate.bind(null,  dir.RIGHT, null)}
+        />
+        <SlideTransition
+          ref='animation'
+          duration={duration}
+          direction={slideDirection}
+          onAnimate={() => focused && this.focus()}
         >
-          <Header
-              label={this._label()}
-              labelId={labelID}
-              messages={messages}
-              upDisabled={isDisabled || view === finalView}
-              prevDisabled={isDisabled || !dates.inRange(this.nextDate(dir.LEFT), min, max, view)}
-              nextDisabled={isDisabled || !dates.inRange(this.nextDate(dir.RIGHT), min, max, view)}
-              onViewChange={this.navigate.bind(null, dir.UP, null)}
-              onMoveLeft={this.navigate.bind(null, dir.LEFT, null)}
-              onMoveRight={this.navigate.bind(null, dir.RIGHT, null)}
+          <View
+            {...viewProps}
+            key={key}
+            id={viewID}
+            value={value}
+            today={todaysDate}
+            focused={currentDate}
+            onChange={this.change}
+            onKeyDown={this.handleKeyDown}
+            aria-labelledby={labelID}
+            ariaActiveDescendantKey='calendarView'
           />
-          <SlideTransition
-              ref='animation'
-              duration={duration}
-              direction={slideDirection}
-              onAnimate={() => focused && this.focus()}
-          >
-            <View
-                {...viewProps}
-                key={key}
-                id={viewID}
-                value={value}
-                today={todaysDate}
-                focused={currentDate}
-                onChange={this.change}
-                onKeyDown={this.handleKeyDown}
-                aria-labelledby={labelID}
-                ariaActiveDescendantKey='calendarView'
-            />
-          </SlideTransition>
-          {footer &&
+        </SlideTransition>
+        {footer &&
           <Footer
-              value={todaysDate}
-              format={footerFormat}
-              culture={culture}
-              disabled={disabled || todayNotInRange}
-              readOnly={readOnly}
-              onClick={this.select}
+            value={todaysDate}
+            format={footerFormat}
+            culture={culture}
+            disabled={disabled || todayNotInRange}
+            readOnly={readOnly}
+            onClick={this.select}
           />
-          }
-        </Widget>
+        }
+      </Widget>
     )
   },
 
   @widgetEditable
-  navigate(direction, date) {
-    var view = this.state.view
-        , slideDir = (direction === dir.LEFT || direction === dir.UP)
-        ? 'right'
-        : 'left';
+  navigate(direction, date){
+    var view     =  this.state.view
+      , slideDir = (direction === dir.LEFT || direction === dir.UP)
+          ? 'right'
+          : 'left';
 
-    if (!date)
-      date = [dir.LEFT, dir.RIGHT].indexOf(direction) !== -1
-          ? this.nextDate(direction)
-          : this.props.currentDate
+    if ( !date )
+      date = [ dir.LEFT, dir.RIGHT ].indexOf(direction) !== -1
+        ? this.nextDate(direction)
+        : this.props.currentDate
 
-    if (direction === dir.DOWN)
+    if (direction === dir.DOWN )
       view = ALT_VIEW[view] || view
 
-    if (direction === dir.UP)
+    if (direction === dir.UP )
       view = NEXT_VIEW[view] || view
 
     if (this.isValidView(view) && dates.inRange(date, this.props.min, this.props.max, view)) {
@@ -309,8 +309,8 @@ let Calendar = createReactClass({
   },
 
   @widgetEditable
-  change(date) {
-    if (this.state.view === this.props.initialView) {
+  change(date){
+    if (this.state.view === this.props.initialView){
       this.changeCurrentDate(date)
       notify(this.props.onChange, date)
       this.focus();
@@ -318,6 +318,124 @@ let Calendar = createReactClass({
     }
 
     this.navigate(dir.DOWN, date)
+  },
+
+  changeCurrentDate(date, currentDate = this.props.currentDate){
+    var inRangeDate = this.inRangeValue(date ? new Date(date) : currentDate)
+    if (dates.eq(inRangeDate, dateOrNull(currentDate), VIEW_UNIT[this.state.view])) return
+    notify(this.props.onCurrentDateChange, inRangeDate)
+  },
+
+  @widgetEditable
+  select(date){
+    var view = this.props.initialView
+      , slideDir = view !== this.state.view || dates.gt(date, this.state.currentDate)
+          ? 'left' // move down to a the view
+          : 'right';
+
+    notify(this.props.onChange, date)
+
+    if (this.isValidView(view) && dates.inRange(date, this.props.min, this.props.max, view)) {
+      this.focus();
+
+      this.changeCurrentDate(date);
+
+      this.setState({
+        slideDirection: slideDir,
+        view: view
+      })
+    }
+  },
+
+  nextDate(direction) {
+    var method = direction === dir.LEFT ? 'subtract' : 'add'
+      , view   = this.state.view
+      , unit   = view === views.MONTH ? view : views.YEAR
+      , multi  = MULTIPLIER[view] || 1;
+
+    return dates[method](this.props.currentDate, 1 * multi, unit)
+  },
+
+   @widgetEditable
+  handleKeyDown(e) {
+    var ctrl = e.ctrlKey
+      , key  = e.key
+      , direction = ARROWS_TO_DIRECTION[key]
+      , current = this.props.currentDate
+      , view = this.state.view
+      , unit = VIEW_UNIT[view]
+      , currentDate = current;
+
+    if ( key === 'Enter'){
+      e.preventDefault()
+      return this.change(current)
+    }
+
+    if ( direction ) {
+      if ( ctrl ) {
+        e.preventDefault()
+        this.navigate(direction)
+      }
+      else {
+        if ( this.isRtl() && OPPOSITE_DIRECTION[direction] )
+          direction = OPPOSITE_DIRECTION[direction]
+
+        currentDate = dates.move(currentDate, this.props.min, this.props.max, view, direction)
+
+        if (!dates.eq(current, currentDate, unit)) {
+          e.preventDefault()
+
+          if ( dates.gt(currentDate, current, view))
+            this.navigate(dir.RIGHT, currentDate)
+
+          else if ( dates.lt(currentDate, current, view))
+            this.navigate(dir.LEFT, currentDate)
+
+          else
+            this.changeCurrentDate(currentDate)
+        }
+      }
+    }
+
+    notify(this.props.onKeyDown, [e])
+  },
+
+  _label() {
+    var {
+        culture
+      , ...props } = this.props
+      , view = this.state.view
+      , dt   = this.props.currentDate;
+
+    if ( view === 'month')
+      return dateLocalizer.format(dt, format(props, 'header'), culture)
+
+    else if ( view === 'year')
+      return dateLocalizer.format(dt, format(props, 'year'), culture)
+
+    else if ( view === 'decade')
+      return dateLocalizer.format(dates.startOf(dt, 'decade'), format(props, 'decade'), culture)
+
+    else if ( view === 'century')
+      return dateLocalizer.format(dates.startOf(dt, 'century'), format(props, 'century'), culture)
+  },
+
+  inRangeValue(_value){
+    var value = dateOrNull(_value)
+
+    if( value === null) return value
+
+    return dates.max(
+        dates.min(value, this.props.max)
+      , this.props.min)
+  },
+
+  isValidView(next) {
+    var bottom  = VIEW_OPTIONS.indexOf(this.props.initialView)
+      , top     = VIEW_OPTIONS.indexOf(this.props.finalView)
+      , current = VIEW_OPTIONS.indexOf(next);
+
+    return current >= bottom && current <= top
   }
 });
 

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -1,4 +1,6 @@
+import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cn from 'classnames';
 
 import compat from './util/compat';
@@ -62,21 +64,21 @@ let propTypes = {
   disabled:       CustomPropTypes.disabled,
   readOnly:       CustomPropTypes.readOnly,
 
-  onChange:      React.PropTypes.func,
-  value:         React.PropTypes.instanceOf(Date),
+  onChange:      PropTypes.func,
+  value:         PropTypes.instanceOf(Date),
 
-  min:           React.PropTypes.instanceOf(Date),
-  max:           React.PropTypes.instanceOf(Date),
+  min:           PropTypes.instanceOf(Date),
+  max:           PropTypes.instanceOf(Date),
 
-  currentDate:         React.PropTypes.instanceOf(Date),
-  onCurrentDateChange: React.PropTypes.func,
+  currentDate:         PropTypes.instanceOf(Date),
+  onCurrentDateChange: PropTypes.func,
 
-  view: React.PropTypes.oneOf(VIEW_OPTIONS),
-  initialView: React.PropTypes.oneOf(VIEW_OPTIONS),
+  view: PropTypes.oneOf(VIEW_OPTIONS),
+  initialView: PropTypes.oneOf(VIEW_OPTIONS),
 
 
   finalView(props, propName, componentName, ...args) {
-    var err = React.PropTypes.oneOf(VIEW_OPTIONS)(props, propName, componentName, ...args)
+    var err = PropTypes.oneOf(VIEW_OPTIONS)(props, propName, componentName, ...args)
 
     if (err) return err
     if (VIEW_OPTIONS.indexOf(props[propName]) < VIEW_OPTIONS.indexOf(props.initialView))
@@ -84,10 +86,10 @@ let propTypes = {
         prop. This creates a range that cannot be rendered.`.replace(/\n\t/g, ''))
   },
 
-  onViewChange:  React.PropTypes.func,
-  onNavigate:    React.PropTypes.func,
-  culture:       React.PropTypes.string,
-  footer:        React.PropTypes.bool,
+  onViewChange:  PropTypes.func,
+  onNavigate:    PropTypes.func,
+  culture:       PropTypes.string,
+  footer:        PropTypes.bool,
 
   dayComponent:  CustomPropTypes.elementType,
   headerFormat:  CustomPropTypes.dateFormat,
@@ -100,13 +102,13 @@ let propTypes = {
   decadeFormat:  CustomPropTypes.dateFormat,
   centuryFormat: CustomPropTypes.dateFormat,
 
-  messages:      React.PropTypes.shape({
-    moveBack:     React.PropTypes.string,
-    moveForward:  React.PropTypes.string
+  messages:      PropTypes.shape({
+    moveBack:     PropTypes.string,
+    moveForward:  PropTypes.string
   })
 }
 
-let Calendar = React.createClass({
+let Calendar = createReactClass({
 
   displayName: 'Calendar',
 
@@ -126,7 +128,7 @@ let Calendar = React.createClass({
 
   propTypes,
 
-  getInitialState(){
+  getInitialState() {
     return {
       selectedIndex: 0,
       view: this.props.initialView || 'month'
@@ -136,16 +138,16 @@ let Calendar = React.createClass({
   getDefaultProps() {
     return {
 
-      value:        null,
-      min:          new Date(1900, 0, 1),
-      max:          new Date(2099, 11, 31),
-      currentDate:  new Date(),
+      value: null,
+      min: new Date(1900, 0, 1),
+      max: new Date(2099, 11, 31),
+      currentDate: new Date(),
 
-      initialView:  'month',
-      finalView:    'century',
+      initialView: 'month',
+      finalView: 'century',
 
-      tabIndex:     '0',
-      footer:        false,
+      tabIndex: '0',
+      footer: false,
 
       ariaActiveDescendantKey: 'calendar',
       messages: msgs({})
@@ -157,19 +159,19 @@ let Calendar = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    var bottom  = VIEW_OPTIONS.indexOf(nextProps.initialView)
-      , top     = VIEW_OPTIONS.indexOf(nextProps.finalView)
-      , current = VIEW_OPTIONS.indexOf(this.state.view)
-      , view    = this.state.view
-      , val     = this.inRangeValue(nextProps.value);
+    var bottom = VIEW_OPTIONS.indexOf(nextProps.initialView)
+        , top = VIEW_OPTIONS.indexOf(nextProps.finalView)
+        , current = VIEW_OPTIONS.indexOf(this.state.view)
+        , view = this.state.view
+        , val = this.inRangeValue(nextProps.value);
 
-    if( current < bottom )
-      this.setState({ view: view = nextProps.initialView })
+    if (current < bottom)
+      this.setState({view: view = nextProps.initialView})
     else if (current > top)
-      this.setState({ view: view = nextProps.finalView })
+      this.setState({view: view = nextProps.finalView})
 
     //if the value changes reset views to the new one
-    if ( !dates.eq(val, dateOrNull(this.props.value), VIEW_UNIT[view])) {
+    if (!dates.eq(val, dateOrNull(this.props.value), VIEW_UNIT[view])) {
       this.changeCurrentDate(val, nextProps.currentDate)
     }
   },
@@ -177,7 +179,7 @@ let Calendar = React.createClass({
   render() {
 
     let {
-        className
+      className
       , value
       , footerFormat
       , disabled
@@ -190,101 +192,102 @@ let Calendar = React.createClass({
       , culture
       , duration
       , tabIndex
-      , currentDate } = this.props
+      , currentDate
+    } = this.props
 
-    let { view, slideDirection, focused } = this.state;
+    let {view, slideDirection, focused} = this.state;
 
     var View = VIEW[view]
-      , unit = VIEW_UNIT[view]
-      , todaysDate = new Date()
-      , todayNotInRange = !dates.inRange(todaysDate, min, max, view)
+        , unit = VIEW_UNIT[view]
+        , todaysDate = new Date()
+        , todayNotInRange = !dates.inRange(todaysDate, min, max, view)
 
     unit = unit === 'day' ? 'date' : unit
 
     let viewID = instanceId(this, '_calendar')
-      , labelID = instanceId(this, '_calendar_label')
-      , key = view + '_' + dates[view](currentDate);
+        , labelID = instanceId(this, '_calendar_label')
+        , key = view + '_' + dates[view](currentDate);
 
     let elementProps = _.omitOwnProps(this)
-      , viewProps  = _.pickProps(this.props, View)
+        , viewProps = _.pickProps(this.props, View)
 
     let isDisabled = disabled || readOnly
 
     messages = msgs(this.props.messages)
 
     return (
-      <Widget
-        {...elementProps}
-        role='group'
-        focused={focused}
-        disabled={disabled}
-        readOnly={readOnly}
-        tabIndex={tabIndex || 0}
-        onBlur={this.handleBlur}
-        onFocus={this.handleFocus}
-        onKeyDown={this.handleKeyDown}
-        className={cn(className, 'rw-calendar')}
-      >
-        <Header
-          label={this._label()}
-          labelId={labelID}
-          messages={messages}
-          upDisabled={  isDisabled || view === finalView}
-          prevDisabled={isDisabled || !dates.inRange(this.nextDate(dir.LEFT), min, max, view)}
-          nextDisabled={isDisabled || !dates.inRange(this.nextDate(dir.RIGHT), min, max, view)}
-          onViewChange={this.navigate.bind(null, dir.UP, null)}
-          onMoveLeft ={this.navigate.bind(null,  dir.LEFT, null)}
-          onMoveRight={this.navigate.bind(null,  dir.RIGHT, null)}
-        />
-        <SlideTransition
-          ref='animation'
-          duration={duration}
-          direction={slideDirection}
-          onAnimate={() => focused && this.focus()}
-        >
-          <View
-            {...viewProps}
-            key={key}
-            id={viewID}
-            value={value}
-            today={todaysDate}
-            focused={currentDate}
-            onChange={this.change}
-            onKeyDown={this.handleKeyDown}
-            aria-labelledby={labelID}
-            ariaActiveDescendantKey='calendarView'
-          />
-        </SlideTransition>
-        {footer &&
-          <Footer
-            value={todaysDate}
-            format={footerFormat}
-            culture={culture}
-            disabled={disabled || todayNotInRange}
+        <Widget
+            {...elementProps}
+            role='group'
+            focused={focused}
+            disabled={disabled}
             readOnly={readOnly}
-            onClick={this.select}
+            tabIndex={tabIndex || 0}
+            onBlur={this.handleBlur}
+            onFocus={this.handleFocus}
+            onKeyDown={this.handleKeyDown}
+            className={cn(className, 'rw-calendar')}
+        >
+          <Header
+              label={this._label()}
+              labelId={labelID}
+              messages={messages}
+              upDisabled={isDisabled || view === finalView}
+              prevDisabled={isDisabled || !dates.inRange(this.nextDate(dir.LEFT), min, max, view)}
+              nextDisabled={isDisabled || !dates.inRange(this.nextDate(dir.RIGHT), min, max, view)}
+              onViewChange={this.navigate.bind(null, dir.UP, null)}
+              onMoveLeft={this.navigate.bind(null, dir.LEFT, null)}
+              onMoveRight={this.navigate.bind(null, dir.RIGHT, null)}
           />
-        }
-      </Widget>
+          <SlideTransition
+              ref='animation'
+              duration={duration}
+              direction={slideDirection}
+              onAnimate={() => focused && this.focus()}
+          >
+            <View
+                {...viewProps}
+                key={key}
+                id={viewID}
+                value={value}
+                today={todaysDate}
+                focused={currentDate}
+                onChange={this.change}
+                onKeyDown={this.handleKeyDown}
+                aria-labelledby={labelID}
+                ariaActiveDescendantKey='calendarView'
+            />
+          </SlideTransition>
+          {footer &&
+          <Footer
+              value={todaysDate}
+              format={footerFormat}
+              culture={culture}
+              disabled={disabled || todayNotInRange}
+              readOnly={readOnly}
+              onClick={this.select}
+          />
+          }
+        </Widget>
     )
   },
 
   @widgetEditable
-  navigate(direction, date){
-    var view     =  this.state.view
-      , slideDir = (direction === dir.LEFT || direction === dir.UP)
-          ? 'right'
-          : 'left';
+  navigate(direction, date) {
+    var view = this.state.view
+        , slideDir = (direction === dir.LEFT || direction === dir.UP)
+        ? 'right'
+        : 'left';
 
-    if ( !date )
-      date = [ dir.LEFT, dir.RIGHT ].indexOf(direction) !== -1
-        ? this.nextDate(direction)
-        : this.props.currentDate
+    if (!date)
+      date = [dir.LEFT, dir.RIGHT].indexOf(direction) !== -1
+          ? this.nextDate(direction)
+          : this.props.currentDate
 
-    if (direction === dir.DOWN )
+    if (direction === dir.DOWN)
       view = ALT_VIEW[view] || view
 
-    if (direction === dir.UP )
+    if (direction === dir.UP)
       view = NEXT_VIEW[view] || view
 
     if (this.isValidView(view) && dates.inRange(date, this.props.min, this.props.max, view)) {
@@ -306,8 +309,8 @@ let Calendar = React.createClass({
   },
 
   @widgetEditable
-  change(date){
-    if (this.state.view === this.props.initialView){
+  change(date) {
+    if (this.state.view === this.props.initialView) {
       this.changeCurrentDate(date)
       notify(this.props.onChange, date)
       this.focus();
@@ -315,124 +318,6 @@ let Calendar = React.createClass({
     }
 
     this.navigate(dir.DOWN, date)
-  },
-
-  changeCurrentDate(date, currentDate = this.props.currentDate){
-    var inRangeDate = this.inRangeValue(date ? new Date(date) : currentDate)
-    if (dates.eq(inRangeDate, dateOrNull(currentDate), VIEW_UNIT[this.state.view])) return
-    notify(this.props.onCurrentDateChange, inRangeDate)
-  },
-
-  @widgetEditable
-  select(date){
-    var view = this.props.initialView
-      , slideDir = view !== this.state.view || dates.gt(date, this.state.currentDate)
-          ? 'left' // move down to a the view
-          : 'right';
-
-    notify(this.props.onChange, date)
-
-    if (this.isValidView(view) && dates.inRange(date, this.props.min, this.props.max, view)) {
-      this.focus();
-
-      this.changeCurrentDate(date);
-
-      this.setState({
-        slideDirection: slideDir,
-        view: view
-      })
-    }
-  },
-
-  nextDate(direction) {
-    var method = direction === dir.LEFT ? 'subtract' : 'add'
-      , view   = this.state.view
-      , unit   = view === views.MONTH ? view : views.YEAR
-      , multi  = MULTIPLIER[view] || 1;
-
-    return dates[method](this.props.currentDate, 1 * multi, unit)
-  },
-
-   @widgetEditable
-  handleKeyDown(e) {
-    var ctrl = e.ctrlKey
-      , key  = e.key
-      , direction = ARROWS_TO_DIRECTION[key]
-      , current = this.props.currentDate
-      , view = this.state.view
-      , unit = VIEW_UNIT[view]
-      , currentDate = current;
-
-    if ( key === 'Enter'){
-      e.preventDefault()
-      return this.change(current)
-    }
-
-    if ( direction ) {
-      if ( ctrl ) {
-        e.preventDefault()
-        this.navigate(direction)
-      }
-      else {
-        if ( this.isRtl() && OPPOSITE_DIRECTION[direction] )
-          direction = OPPOSITE_DIRECTION[direction]
-
-        currentDate = dates.move(currentDate, this.props.min, this.props.max, view, direction)
-
-        if (!dates.eq(current, currentDate, unit)) {
-          e.preventDefault()
-
-          if ( dates.gt(currentDate, current, view))
-            this.navigate(dir.RIGHT, currentDate)
-
-          else if ( dates.lt(currentDate, current, view))
-            this.navigate(dir.LEFT, currentDate)
-
-          else
-            this.changeCurrentDate(currentDate)
-        }
-      }
-    }
-
-    notify(this.props.onKeyDown, [e])
-  },
-
-  _label() {
-    var {
-        culture
-      , ...props } = this.props
-      , view = this.state.view
-      , dt   = this.props.currentDate;
-
-    if ( view === 'month')
-      return dateLocalizer.format(dt, format(props, 'header'), culture)
-
-    else if ( view === 'year')
-      return dateLocalizer.format(dt, format(props, 'year'), culture)
-
-    else if ( view === 'decade')
-      return dateLocalizer.format(dates.startOf(dt, 'decade'), format(props, 'decade'), culture)
-
-    else if ( view === 'century')
-      return dateLocalizer.format(dates.startOf(dt, 'century'), format(props, 'century'), culture)
-  },
-
-  inRangeValue(_value){
-    var value = dateOrNull(_value)
-
-    if( value === null) return value
-
-    return dates.max(
-        dates.min(value, this.props.max)
-      , this.props.min)
-  },
-
-  isValidView(next) {
-    var bottom  = VIEW_OPTIONS.indexOf(this.props.initialView)
-      , top     = VIEW_OPTIONS.indexOf(this.props.finalView)
-      , current = VIEW_OPTIONS.indexOf(next);
-
-    return current >= bottom && current <= top
   }
 });
 

--- a/src/CalendarView.js
+++ b/src/CalendarView.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import cn from 'classnames';
 
@@ -31,16 +32,16 @@ class CalendarView extends React.Component {
 
 class CalendarViewCell extends React.Component {
   static propTypes = {
-    id: React.PropTypes.string,
-    label: React.PropTypes.string,
-    today: React.PropTypes.instanceOf(Date),
-    selected: React.PropTypes.instanceOf(Date),
-    focused: React.PropTypes.instanceOf(Date),
-    min: React.PropTypes.instanceOf(Date),
-    max: React.PropTypes.instanceOf(Date),
-    unit: React.PropTypes.oneOf(['day', ...VIEW_UNITS]),
-    viewUnit: React.PropTypes.oneOf(VIEW_UNITS),
-    onChange: React.PropTypes.func.isRequired
+    id: PropTypes.string,
+    label: PropTypes.string,
+    today: PropTypes.instanceOf(Date),
+    selected: PropTypes.instanceOf(Date),
+    focused: PropTypes.instanceOf(Date),
+    min: PropTypes.instanceOf(Date),
+    max: PropTypes.instanceOf(Date),
+    unit: PropTypes.oneOf(['day', ...VIEW_UNITS]),
+    viewUnit: PropTypes.oneOf(VIEW_UNITS),
+    onChange: PropTypes.func.isRequired
   };
 
   isEqual(date) {

--- a/src/Century.jsx
+++ b/src/Century.jsx
@@ -1,4 +1,7 @@
+import PropTypes from 'prop-types';
 import React from 'react';
+
+import createReactClass from 'create-react-class';
 
 import CalendarView from './CalendarView';
 import dates  from './util/dates';
@@ -12,17 +15,17 @@ let format = props => dateLocalizer.getFormat('decade', props.decadeFormat)
 let optionId = (id, date) => `${id}__century_${dates.year(date)}`;
 
 let propTypes = {
-  culture: React.PropTypes.string,
-  today: React.PropTypes.instanceOf(Date),
-  value: React.PropTypes.instanceOf(Date),
-  focused: React.PropTypes.instanceOf(Date),
-  min: React.PropTypes.instanceOf(Date),
-  max: React.PropTypes.instanceOf(Date),
-  onChange: React.PropTypes.func.isRequired,
+  culture: PropTypes.string,
+  today: PropTypes.instanceOf(Date),
+  value: PropTypes.instanceOf(Date),
+  focused: PropTypes.instanceOf(Date),
+  min: PropTypes.instanceOf(Date),
+  max: PropTypes.instanceOf(Date),
+  onChange: PropTypes.func.isRequired,
   decadeFormat: CustomPropTypes.dateFormat
 };
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'CenturyView',
 

--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -1,4 +1,6 @@
+import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cn from 'classnames';
 import _  from './util/_';
 import filter from './util/filter';
@@ -25,10 +27,10 @@ let propTypes = {
   ...Popup.propTypes,
 
   //-- controlled props -----------
-  value:          React.PropTypes.any,
-  onChange:       React.PropTypes.func,
-  open:           React.PropTypes.bool,
-  onToggle:       React.PropTypes.func,
+  value:          PropTypes.any,
+  onChange:       PropTypes.func,
+  open:           PropTypes.bool,
+  onToggle:       PropTypes.func,
   //------------------------------------
 
   itemComponent:  CustomPropTypes.elementType,
@@ -37,36 +39,36 @@ let propTypes = {
   groupComponent: CustomPropTypes.elementType,
   groupBy:        CustomPropTypes.accessor,
 
-  data:           React.PropTypes.array,
-  valueField:     React.PropTypes.string,
+  data:           PropTypes.array,
+  valueField:     PropTypes.string,
   textField:      CustomPropTypes.accessor,
-  name:           React.PropTypes.string,
+  name:           PropTypes.string,
 
-  onSelect:       React.PropTypes.func,
+  onSelect:       PropTypes.func,
 
-  autoFocus:      React.PropTypes.bool,
+  autoFocus:      PropTypes.bool,
   disabled:       CustomPropTypes.disabled.acceptsArray,
   readOnly:       CustomPropTypes.readOnly.acceptsArray,
 
   suggest:        CustomPropTypes.filter,
   filter:         CustomPropTypes.filter,
 
-  busy:           React.PropTypes.bool,
+  busy:           PropTypes.bool,
 
-  dropUp:         React.PropTypes.bool,
-  duration:       React.PropTypes.number,
-  delay:          React.PropTypes.number,
+  dropUp:         PropTypes.bool,
+  duration:       PropTypes.number,
+  delay:          PropTypes.number,
 
-  placeholder:    React.PropTypes.string,
+  placeholder:    PropTypes.string,
 
-  messages:       React.PropTypes.shape({
+  messages:       PropTypes.shape({
     open:         CustomPropTypes.message,
     emptyList:    CustomPropTypes.message,
     emptyFilter:  CustomPropTypes.message
   })
 };
 
-var ComboBox = React.createClass({
+var ComboBox = createReactClass({
 
   displayName: 'ComboBox',
 
@@ -298,153 +300,6 @@ var ComboBox = React.createClass({
     notify(this.props.onSelect, data)
     this.change(data)
     this.focus();
-  },
-
-  handleInputKeyDown(e){
-    this._deleting = e.key === 'Backspace' || e.key === 'Delete'
-    this._isTyping = true
-  },
-
-  handleInputChange(e){
-    let { data, textField } = this.props
-
-    var shouldSuggest = !!this.props.suggest
-      , strVal  = e.target.value
-      , suggestion;
-
-    suggestion = this._deleting || !shouldSuggest
-      ? strVal : this.suggest(this._data(), strVal)
-
-    suggestion = suggestion || strVal
-
-    data = _.find(data,
-      item => dataText(item, textField).toLowerCase() === suggestion.toLowerCase())
-
-    this.change(!this._deleting && data
-      ? data
-      : strVal, true)
-
-    this.open()
-  },
-
-  focus() {
-    this.refs.input &&
-      this.refs.input.focus()
-  },
-
-  @widgetEditable
-  handleKeyDown(e){
-    var self = this
-      , key  = e.key
-      , alt  = e.altKey
-      , list = this.refs.list
-      , focusedItem = this.state.focusedItem
-      , selectedItem = this.state.selectedItem
-      , isOpen = this.props.open;
-
-    notify(this.props.onKeyDown, [e])
-    if (e.defaultPrevented)
-      return
-
-    if (key === 'End')
-      if ( isOpen ) this.setState({ focusedItem: list.last() })
-      else          select(list.last(), true)
-
-    else if (key === 'Home')
-      if (isOpen) this.setState({ focusedItem: list.first() })
-      else          select(list.first(), true)
-
-    else if (key === 'Escape' && isOpen)
-      this.close()
-
-    else if (key === 'Enter' && isOpen) {
-      e.preventDefault();
-      select(this.state.focusedItem, true)
-    }
-    else if (key === 'ArrowDown') {
-      if ( alt )
-        this.open()
-      else {
-        if ( isOpen ) this.setState({ focusedItem: list.next(focusedItem) })
-        else          select(list.next(selectedItem), true)
-      }
-    }
-    else if ( key === 'ArrowUp' ) {
-      if ( alt )
-        this.close()
-      else {
-        if ( isOpen ) this.setState({ focusedItem: list.prev(focusedItem) })
-        else          select(list.prev(selectedItem), true)
-      }
-    }
-
-    function select(item, fromList) {
-      if(!item)
-        return self.change(compat.findDOMNode(self.refs.input).value, false)
-
-      self.refs.input.accept(true); //removes caret
-
-      if(fromList)
-        return self.handleSelect(item)
-
-      self.change(item, false)
-    }
-  },
-
-  change(data, typing){
-    this._typedChange = !!typing
-    notify(this.props.onChange, data)
-  },
-
-  open(){
-    if ( !this.props.open )
-      notify(this.props.onToggle, true)
-  },
-
-  close(){
-    if ( this.props.open )
-      notify(this.props.onToggle, false)
-  },
-
-  @widgetEditable
-  toggle(){
-    this.focus()
-
-    this.props.open
-      ? this.close()
-      : this.open()
-  },
-
-  suggest(data, value) {
-    let { textField, suggest, minLength } = this.props
-
-    var word = dataText(value, textField)
-      , suggestion;
-
-    suggest = defaultSuggest(suggest)
-
-    if (!(word || '').trim() || word.length < (minLength || 1))
-      return ''
-
-    suggestion = typeof value === 'string'
-        ? _.find(data, getFilter(suggest, word, textField))
-        : value
-
-    if ( suggestion && (!this.state || !this.state.deleting))
-      return dataText(suggestion, textField)
-
-    return ''
-  },
-
-  _data() {
-    return this.state.processedData
-  },
-
-  process(data, values, searchTerm) {
-    if (this.props.filter && searchTerm)
-      data = this.filter(data, searchTerm)
-
-    return data
   }
 })
 

--- a/src/ComboboxInput.jsx
+++ b/src/ComboboxInput.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _  from './util/_';
 import caretPos from './util/caret';
@@ -5,15 +6,18 @@ import compat from './util/compat';
 
 import Input from './Input';
 
-export default React.createClass({
+export default class extends React.Component {
+  static displayName = 'ComboboxInput';
 
-  displayName: 'ComboboxInput',
+  static propTypes = {
+    value: PropTypes.string,
+    suggest: PropTypes.bool,
+    onChange: PropTypes.func.isRequired
+  };
 
-  propTypes: {
-    value: React.PropTypes.string,
-    suggest: React.PropTypes.bool,
-    onChange: React.PropTypes.func.isRequired
-  },
+  static defaultProps = {
+    value: ''
+  };
 
   componentDidUpdate() {
     var input = compat.findDOMNode(this)
@@ -27,13 +31,7 @@ export default React.createClass({
         caretPos(input, start, start + end)
       }
     }
-  },
-
-  getDefaultProps(){
-    return {
-      value: ''
-    }
-  },
+  }
 
   render() {
     let { onKeyDown, ...props } = this.props;
@@ -47,25 +45,25 @@ export default React.createClass({
         onChange={this.handleChange}
       />
     )
-  },
+  }
 
-  isSuggesting() {
+  isSuggesting = () => {
     var val = this.props.value
       , isSuggestion = this._last != null
           && val.toLowerCase().indexOf(this._last.toLowerCase()) !== -1;
 
     return this.props.suggest && isSuggestion
-  },
+  };
 
-  accept(removeCaret) {
+  accept = (removeCaret) => {
     var val = compat.findDOMNode(this).value || ''
       , end = val.length;
 
     this._last = null
     removeCaret && caretPos(compat.findDOMNode(this), end, end)
-  },
+  };
 
-  handleChange(e) {
+  handleChange = (e) => {
     var val = e.target.value
       , pl = !!this.props.placeholder
 
@@ -76,9 +74,9 @@ export default React.createClass({
 
     this._last = val;
     this.props.onChange(e, val)
-  },
+  };
 
-  focus() {
+  focus = () => {
     compat.findDOMNode(this).focus()
-  }
-});
+  };
+}

--- a/src/DateTimePicker.jsx
+++ b/src/DateTimePicker.jsx
@@ -1,4 +1,5 @@
-import React  from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import invariant from 'invariant';
 import activeElement from 'dom-helpers/activeElement';
 import cn from 'classnames';
@@ -31,60 +32,60 @@ let propTypes = {
     ...Calendar.propTypes,
 
     //-- controlled props -----------
-    value:          React.PropTypes.instanceOf(Date),
-    onChange:       React.PropTypes.func,
-    open:           React.PropTypes.oneOf([false, popups.TIME, popups.CALENDAR]),
-    onToggle:       React.PropTypes.func,
-    currentDate:    React.PropTypes.instanceOf(Date),
-    onCurrentDateChange: React.PropTypes.func,
+    value:          PropTypes.instanceOf(Date),
+    onChange:       PropTypes.func,
+    open:           PropTypes.oneOf([false, popups.TIME, popups.CALENDAR]),
+    onToggle:       PropTypes.func,
+    currentDate:    PropTypes.instanceOf(Date),
+    onCurrentDateChange: PropTypes.func,
     //------------------------------------
 
-    onSelect:       React.PropTypes.func,
+    onSelect:       PropTypes.func,
 
-    min:            React.PropTypes.instanceOf(Date),
-    max:            React.PropTypes.instanceOf(Date),
+    min:            PropTypes.instanceOf(Date),
+    max:            PropTypes.instanceOf(Date),
 
-    culture:        React.PropTypes.string,
+    culture:        PropTypes.string,
 
     format:         CustomPropTypes.dateFormat,
     timeFormat:     CustomPropTypes.dateFormat,
     editFormat:     CustomPropTypes.dateFormat,
 
-    calendar:       React.PropTypes.bool,
-    time:           React.PropTypes.bool,
+    calendar:       PropTypes.bool,
+    time:           PropTypes.bool,
 
     timeComponent:  CustomPropTypes.elementType,
 
     //popup
-    dropUp:         React.PropTypes.bool,
-    duration:       React.PropTypes.number,
+    dropUp:         PropTypes.bool,
+    duration:       PropTypes.number,
 
-    placeholder:    React.PropTypes.string,
-    name:           React.PropTypes.string,
+    placeholder:    PropTypes.string,
+    name:           PropTypes.string,
 
-    initialView:    React.PropTypes.oneOf(viewEnum),
-    finalView:      React.PropTypes.oneOf(viewEnum),
+    initialView:    PropTypes.oneOf(viewEnum),
+    finalView:      PropTypes.oneOf(viewEnum),
 
-    autoFocus:      React.PropTypes.bool,
+    autoFocus:      PropTypes.bool,
     disabled:       CustomPropTypes.disabled,
     readOnly:       CustomPropTypes.readOnly,
 
-    parse:          React.PropTypes.oneOfType([
-                      React.PropTypes.arrayOf(React.PropTypes.string),
-                      React.PropTypes.string,
-                      React.PropTypes.func
+    parse:          PropTypes.oneOfType([
+                      PropTypes.arrayOf(PropTypes.string),
+                      PropTypes.string,
+                      PropTypes.func
                     ]),
 
-    'aria-labelledby': React.PropTypes.string,
+    'aria-labelledby': PropTypes.string,
 
-    messages:      React.PropTypes.shape({
-      calendarButton: React.PropTypes.string,
-      timeButton:     React.PropTypes.string
+    messages:      PropTypes.shape({
+      calendarButton: PropTypes.string,
+      timeButton:     PropTypes.string
     })
   }
 
 
-var DateTimePicker = React.createClass({
+var DateTimePicker = createReactClass({
 
   displayName: 'DateTimePicker',
 
@@ -474,7 +475,7 @@ var DateTimePicker = React.createClass({
 
     invariant(formats.length,
       'React Widgets: there are no specified `parse` formats provided and the `format` prop is a function. ' +
-      'the DateTimePicker is unable to parse `%s` into a dateTime, ' +
+'the DateTimePicker is unable to parse `%s` into a dateTime, ' +
       'please provide either a parse function or Globalize.js compatible string for `format`', string);
 
     return formatsParser(formats, this.props.culture, string);
@@ -482,9 +483,9 @@ var DateTimePicker = React.createClass({
 
   toggle(view) {
     this.props.open
-      ? this.props.open !== view
-          ? this.open(view)
-          : this.close(view)
+  ? this.props.open !== view
+      ? this.open(view)
+      : this.close(view)
       : this.open(view)
   },
 

--- a/src/DateTimePickerInput.jsx
+++ b/src/DateTimePickerInput.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import _  from './util/_';
@@ -7,20 +8,32 @@ import compat from './util/compat';
 import { date as dateLocalizer } from './util/localizers';
 import CustomPropTypes from './util/propTypes';
 
-export default React.createClass({
+export default class extends React.Component {
+  static displayName = 'DateTimePickerInput';
 
-  displayName: 'DateTimePickerInput',
-
-  propTypes: {
+  static propTypes = {
     format: CustomPropTypes.dateFormat.isRequired,
-    editing: React.PropTypes.bool,
+    editing: PropTypes.bool,
     editFormat: CustomPropTypes.dateFormat,
-    parse: React.PropTypes.func.isRequired,
+    parse: PropTypes.func.isRequired,
 
-    value: React.PropTypes.instanceOf(Date),
-    onChange: React.PropTypes.func.isRequired,
-    culture: React.PropTypes.string
-  },
+    value: PropTypes.instanceOf(Date),
+    onChange: PropTypes.func.isRequired,
+    culture: PropTypes.string
+  };
+
+  constructor(props) {
+    super(props);
+    let { value, editing, editFormat, format, culture } = props;
+
+    this.state = {
+      textValue: formatDate(
+          value
+        , editing && editFormat ? editFormat : format
+        , culture
+      )
+    };
+  }
 
   componentWillReceiveProps(nextProps) {
     let { value, editing, editFormat, format, culture } = nextProps;
@@ -32,21 +45,9 @@ export default React.createClass({
         , culture
       )
     })
-  },
+  }
 
-  getInitialState() {
-    let { value, editing, editFormat, format, culture } = this.props;
-
-    return {
-      textValue: formatDate(
-          value
-        , editing && editFormat ? editFormat : format
-        , culture
-      )
-    }
-  },
-
-  render(){
+  render() {
     let { disabled, readOnly } = this.props
     let { textValue } = this.state
 
@@ -65,9 +66,9 @@ export default React.createClass({
         size={textValue.length}
       />
     )
-  },
+  }
 
-  handleKeyDown(event) {
+  handleKeyDown = (event) => {
     if(event.key == 'Enter') {
       let date = this.props.parse(event.target.value);
       compat.findDOMNode(this).blur();
@@ -75,14 +76,14 @@ export default React.createClass({
     } else if(event.key == 'Escape') {
       compat.findDOMNode(this).blur();
     }
-  },
+  };
 
-  handleChange({ target: { value } }) {
+  handleChange = ({ target: { value } }) => {
     this._needsFlush = true
     this.setState({ textValue: value });
-  },
+  };
 
-  handleBlur(event) {
+  handleBlur = (event) => {
     let { format, culture, parse, onChange, onBlur } = this.props;
 
     onBlur && onBlur(event)
@@ -93,12 +94,12 @@ export default React.createClass({
       this._needsFlush = false
       onChange(date, formatDate(date, format, culture))
     }
-  },
+  };
 
-  focus(){
+  focus = () => {
     compat.findDOMNode(this).focus()
-  }
-});
+  };
+}
 
 function isValid(d) {
   return !isNaN(d.getTime());

--- a/src/Decade.jsx
+++ b/src/Decade.jsx
@@ -1,4 +1,7 @@
+import PropTypes from 'prop-types';
 import React from 'react';
+
+import createReactClass from 'create-react-class';
 
 import CalendarView from './CalendarView';
 import dates from './util/dates';
@@ -8,20 +11,20 @@ import CustomPropTypes from './util/propTypes';
 import { instanceId } from './util/widgetHelpers';
 
 let propTypes = {
-  culture:      React.PropTypes.string,
-  today:        React.PropTypes.instanceOf(Date),
-  value:        React.PropTypes.instanceOf(Date),
-  focused:      React.PropTypes.instanceOf(Date),
-  min:          React.PropTypes.instanceOf(Date),
-  max:          React.PropTypes.instanceOf(Date),
-  onChange:     React.PropTypes.func.isRequired,
+  culture:      PropTypes.string,
+  today:        PropTypes.instanceOf(Date),
+  value:        PropTypes.instanceOf(Date),
+  focused:      PropTypes.instanceOf(Date),
+  min:          PropTypes.instanceOf(Date),
+  max:          PropTypes.instanceOf(Date),
+  onChange:     PropTypes.func.isRequired,
 
   yearFormat:   CustomPropTypes.dateFormat
 };
 
 let optionId = (id, date) => `${id}__decade_${dates.year(date)}`;
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'DecadeView',
 

--- a/src/DropdownList.jsx
+++ b/src/DropdownList.jsx
@@ -1,4 +1,6 @@
+import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import activeElement from 'dom-helpers/activeElement';
 import contains from 'dom-helpers/query/contains';
 import cx from 'classnames';
@@ -26,14 +28,14 @@ var propTypes = {
   ...Popup.propTypes,
 
   //-- controlled props -----------
-  value:          React.PropTypes.any,
-  onChange:       React.PropTypes.func,
-  open:           React.PropTypes.bool,
-  onToggle:       React.PropTypes.func,
+  value:          PropTypes.any,
+  onChange:       PropTypes.func,
+  open:           PropTypes.bool,
+  onToggle:       PropTypes.func,
   //------------------------------------
 
-  data:           React.PropTypes.array,
-  valueField:     React.PropTypes.string,
+  data:           PropTypes.array,
+  valueField:     PropTypes.string,
   textField:      CustomPropTypes.accessor,
 
   valueComponent: CustomPropTypes.elementType,
@@ -43,18 +45,18 @@ var propTypes = {
   groupComponent: CustomPropTypes.elementType,
   groupBy:        CustomPropTypes.accessor,
 
-  onSelect:       React.PropTypes.func,
-  searchTerm:     React.PropTypes.string,
-  onSearch:       React.PropTypes.func,
-  busy:           React.PropTypes.bool,
-  delay:          React.PropTypes.number,
-  dropUp:         React.PropTypes.bool,
-  duration:       React.PropTypes.number, //popup
+  onSelect:       PropTypes.func,
+  searchTerm:     PropTypes.string,
+  onSearch:       PropTypes.func,
+  busy:           PropTypes.bool,
+  delay:          PropTypes.number,
+  dropUp:         PropTypes.bool,
+  duration:       PropTypes.number, //popup
 
   disabled:       CustomPropTypes.disabled.acceptsArray,
   readOnly:       CustomPropTypes.readOnly.acceptsArray,
 
-  messages:       React.PropTypes.shape({
+  messages:       PropTypes.shape({
     open:              CustomPropTypes.message,
     emptyList:         CustomPropTypes.message,
     emptyFilter:       CustomPropTypes.message,
@@ -62,7 +64,7 @@ var propTypes = {
   })
 };
 
-var DropdownList = React.createClass({
+var DropdownList = createReactClass({
 
   displayName: 'DropdownList',
 
@@ -83,7 +85,7 @@ var DropdownList = React.createClass({
 
   propTypes: propTypes,
 
-  getDefaultProps(){
+  getDefaultProps() {
     return {
       delay: 500,
       value: '',
@@ -95,87 +97,87 @@ var DropdownList = React.createClass({
     }
   },
 
-  getInitialState(){
-    let { open, filter, value, data, searchTerm, valueField } = this.props;
+  getInitialState() {
+    let {open, filter, value, data, searchTerm, valueField} = this.props;
 
     var processed = filter ? this.filter(data, searchTerm) : data
-      , initialIdx = dataIndexOf(data, value, valueField);
+        , initialIdx = dataIndexOf(data, value, valueField);
 
     return {
       filteredData: (open && filter) ? processed : null,
       selectedItem: processed[initialIdx],
-      focusedItem:  processed[initialIdx] || data[0]
+      focusedItem: processed[initialIdx] || data[0]
     }
   },
 
   componentDidUpdate() {
     this.refs.list
-        && validateList(this.refs.list)
+    && validateList(this.refs.list)
   },
 
-  componentWillReceiveProps(props){
-    let { open, filter, value, data, searchTerm, valueField } = props;
+  componentWillReceiveProps(props) {
+    let {open, filter, value, data, searchTerm, valueField} = props;
 
     var processed = filter ? this.filter(data, searchTerm) : data
-      , idx = dataIndexOf(data, value, valueField);
+        , idx = dataIndexOf(data, value, valueField);
 
     this.setState({
       filteredData: (open && filter) ? processed : null,
       selectedItem: processed[idx],
-      focusedItem:  processed[!~idx ? 0 : idx]
+      focusedItem: processed[!~idx ? 0 : idx]
     })
   },
 
-  renderFilter(messages){
+  renderFilter(messages) {
     return (
-      <div ref='filterWrapper' className='rw-filter-input'>
-        <Select component='span' icon='search' />
-        <Input
-          ref='filter'
-          value={this.props.searchTerm}
-          placeholder={_.result(messages.filterPlaceholder, this.props)}
-          onChange={e => notify(this.props.onSearch, e.target.value)}
-        />
+        <div ref='filterWrapper' className='rw-filter-input'>
+          <Select component='span' icon='search'/>
+          <Input
+              ref='filter'
+              value={this.props.searchTerm}
+              placeholder={_.result(messages.filterPlaceholder, this.props)}
+              onChange={e => notify(this.props.onSearch, e.target.value)}
+          />
 
-      </div>
+        </div>
     )
   },
 
   renderList(List, id, messages) {
-    let { open, filter, data } = this.props;
-    let { selectedItem, focusedItem } = this.state;
+    let {open, filter, data} = this.props;
+    let {selectedItem, focusedItem} = this.state;
 
     let listProps = _.pickProps(this.props, List);
     let items = this._data();
 
     return (
-      <div>
-        { filter && this.renderFilter(messages) }
+        <div>
+          {filter && this.renderFilter(messages)}
 
-        <List
-          {...listProps}
-          ref="list"
-          id={id}
-          data={items}
-          aria-live={open && 'polite'}
-          aria-labelledby={instanceId(this)}
-          aria-hidden={!this.props.open}
-          selected={selectedItem}
-          focused ={open ? focusedItem : null}
-          onSelect={this.handleSelect}
-          onMove={this._scrollTo}
-          messages={{
-            emptyList: data.length
-              ? messages.emptyFilter
-              : messages.emptyList
-          }}/>
-      </div>
+          <List
+              {...listProps}
+              ref="list"
+              id={id}
+              data={items}
+              aria-live={open && 'polite'}
+              aria-labelledby={instanceId(this)}
+              aria-hidden={!this.props.open}
+              selected={selectedItem}
+              focused={open ? focusedItem : null}
+              onSelect={this.handleSelect}
+              onMove={this._scrollTo}
+              messages={{
+                emptyList: data.length
+                    ? messages.emptyFilter
+                    : messages.emptyList
+              }}/>
+        </div>
     )
   },
 
   render() {
     let {
-        className
+      className
       , tabIndex
       , duration
       , valueField
@@ -187,16 +189,17 @@ var DropdownList = React.createClass({
       , dropUp
       , placeholder, value, open
       , valueComponent
-      , listComponent: List } = this.props;
+      , listComponent: List
+    } = this.props;
 
     List = List || (groupBy && GroupableList) || PlainList
 
-    let { focused } = this.state;
+    let {focused} = this.state;
 
     let disabled = isDisabled(this.props)
-      , readOnly = isReadOnly(this.props)
-      , valueItem = dataItem(data, value, valueField) // take value from the raw data
-      , listID = instanceId(this, '__listbox');
+        , readOnly = isReadOnly(this.props)
+        , valueItem = dataItem(data, value, valueField) // take value from the raw data
+        , listID = instanceId(this, '__listbox');
 
     let elementProps = Object.assign(_.omitOwnProps(this, List), {
       role: 'combobox',
@@ -216,202 +219,57 @@ var DropdownList = React.createClass({
     messages = msgs(messages)
 
     return (
-      <Widget
-        {...elementProps}
-        ref="input"
-        className={cx(className, 'rw-dropdownlist')}
-        open={open}
-        dropUp={dropUp}
-        focused={focused}
-        disabled={disabled}
-        readOnly={readOnly}
-        onBlur={this.handleBlur}
-        onFocus={this.handleFocus}
-        onClick={this.handleClick}
-        onKeyDown={this.handleKeyDown}
-        onKeyPress={this.handleKeyPress}
-      >
-        <Select
-          busy={busy}
-          icon="caret-down"
-          component='span'
-          className="rw-dropdownlist-picker"
-          label={result(messages.open, this.props)}
-        />
-        <DropdownListInput
-          value={valueItem}
-          textField={textField}
-          placeholder={placeholder}
-          valueComponent={valueComponent}
-        />
-
-        {shouldRenderPopup &&
-          <Popup
+        <Widget
+            {...elementProps}
+            ref="input"
+            className={cx(className, 'rw-dropdownlist')}
             open={open}
             dropUp={dropUp}
-            duration={duration}
-            onOpen={() => this.focus()}
-            onOpening={() => this.refs.list.forceUpdate()}
+            focused={focused}
+            disabled={disabled}
+            readOnly={readOnly}
+            onBlur={this.handleBlur}
+            onFocus={this.handleFocus}
+            onClick={this.handleClick}
+            onKeyDown={this.handleKeyDown}
+            onKeyPress={this.handleKeyPress}
+        >
+          <Select
+              busy={busy}
+              icon="caret-down"
+              component='span'
+              className="rw-dropdownlist-picker"
+              label={result(messages.open, this.props)}
+          />
+          <DropdownListInput
+              value={valueItem}
+              textField={textField}
+              placeholder={placeholder}
+              valueComponent={valueComponent}
+          />
+
+          {shouldRenderPopup &&
+          <Popup
+              open={open}
+              dropUp={dropUp}
+              duration={duration}
+              onOpen={() => this.focus()}
+              onOpening={() => this.refs.list.forceUpdate()}
           >
             {this.renderList(List, listID, messages)}
           </Popup>
-        }
-      </Widget>
+          }
+        </Widget>
     )
   },
 
   @widgetEditable
-  handleSelect(data){
+  handleSelect(data) {
     this.close()
     notify(this.props.onSelect, data)
     this.change(data)
     this.focus(this)
-  },
-
-  @widgetEditable
-  handleClick(e){
-    var wrapper = this.refs.filterWrapper
-
-    if( !this.props.filter || !this.props.open )
-      this.toggle()
-
-    else if( !contains(compat.findDOMNode(wrapper), e.target))
-      this.close()
-
-    notify(this.props.onClick, e)
-  },
-
-  @widgetEditable
-  handleKeyDown(e){
-    var key = e.key
-      , alt = e.altKey
-      , list = this.refs.list
-      , filtering = this.props.filter
-      , focusedItem = this.state.focusedItem
-      , selectedItem = this.state.selectedItem
-      , isOpen = this.props.open
-      , closeWithFocus = () => { this.close(), compat.findDOMNode(this).focus()};
-
-    notify(this.props.onKeyDown, [e])
-
-    let change = (item, fromList) => {
-      if(item == null) return
-      fromList
-        ? this.handleSelect(item)
-        : this.change(item)
-    }
-
-    if (e.defaultPrevented)
-      return
-
-    if (key === 'End') {
-      e.preventDefault()
-
-      if (isOpen) this.setState({ focusedItem: list.last() })
-      else        change(list.last())
-    }
-    else if (key === 'Home') {
-      e.preventDefault()
-
-      if (isOpen) this.setState({ focusedItem: list.first() })
-      else        change(list.first())
-    }
-    else if (key === 'Escape' && isOpen) {
-      e.preventDefault();
-      closeWithFocus()
-    }
-    else if ((key === 'Enter' || (key === ' ' && !filtering)) && isOpen ) {
-      e.preventDefault();
-      change(this.state.focusedItem, true)
-    }
-    else if (key === ' ' && !filtering && !isOpen) {
-      e.preventDefault();
-      this.open()
-    }
-    else if (key === 'ArrowDown') {
-      if (alt)         this.open()
-      else if (isOpen) this.setState({ focusedItem: list.next(focusedItem) })
-      else             change(list.next(selectedItem))
-      e.preventDefault()
-    }
-    else if (key === 'ArrowUp') {
-      if (alt)         closeWithFocus()
-      else if (isOpen) this.setState({ focusedItem: list.prev(focusedItem) })
-      else             change(list.prev(selectedItem))
-      e.preventDefault()
-    }
-  },
-
-  @widgetEditable
-  handleKeyPress(e) {
-    notify(this.props.onKeyPress, [e])
-
-    if (e.defaultPrevented)
-      return
-
-    if (!(this.props.filter && this.props.open))
-      this.search(String.fromCharCode(e.which), item => {
-        this.isMounted() && this.props.open
-          ? this.setState({ focusedItem: item })
-          : item && this.change(item)
-      })
-  },
-
-  change(data){
-    if (!valueMatcher(data, this.props.value, this.props.valueField)) {
-      notify(this.props.onChange, data)
-      notify(this.props.onSearch, '')
-      this.close()
-    }
-  },
-
-  focus(target){
-    let { filter, open } = this.props;
-    let inst = target || (filter && open ? this.refs.filter : this.refs.input);
-
-    inst = compat.findDOMNode(inst);
-
-    if (activeElement() !== inst)
-      inst.focus()
-  },
-
-  _data() {
-    return this.state.filteredData || this.props.data.concat()
-  },
-
-  search(character, cb) {
-    var word = ((this._searchTerm || '') + character).toLowerCase();
-
-    if (!character)
-      return
-
-    this._searchTerm = word
-
-    this.setTimeout('search', () => {
-      var list = this.refs.list
-        , key  = this.props.open ? 'focusedItem' : 'selectedItem'
-        , item = list.next(this.state[key], word);
-
-      this._searchTerm = ''
-      if (item) cb(item)
-
-    }, this.props.delay)
-  },
-
-  open() {
-    notify(this.props.onToggle, true)
-  },
-
-  close() {
-    notify(this.props.onToggle, false)
-  },
-
-  toggle() {
-    this.props.open
-      ? this.close()
-      : this.open()
   }
-
 })
 
 function msgs(msgs){

--- a/src/DropdownListInput.jsx
+++ b/src/DropdownListInput.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import CustomPropTypes from './util/propTypes';
 import { dataText } from './util/dataHelpers';

--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -4,27 +4,25 @@ import { date as dateLocalizer } from './util/localizers';
 
 var format = props => dateLocalizer.getFormat('footer', props.format)
 
-module.exports = React.createClass({
+module.exports = class extends React.Component {
+  static displayName = 'Footer';
 
-    displayName: 'Footer',
+  render() {
+    let { disabled, readOnly, value } = this.props;
 
-    render() {
-      let { disabled, readOnly, value } = this.props;
-
-      return (
-        <div className='rw-footer'>
-          <Button
-            disabled={!!(disabled || readOnly)}
-            onClick={this.props.onClick.bind(null, value)}
-          >
-            {dateLocalizer.format(
-              value,
-              format(this.props),
-              this.props.culture
-            )}
-          </Button>
-        </div>
-      );
-    }
-
-});
+    return (
+      <div className='rw-footer'>
+        <Button
+          disabled={!!(disabled || readOnly)}
+          onClick={this.props.onClick.bind(null, value)}
+        >
+          {dateLocalizer.format(
+            value,
+            format(this.props),
+            this.props.culture
+          )}
+        </Button>
+      </div>
+    );
+  }
+};

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -1,22 +1,24 @@
+import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Button from './Button';
 
-export default React.createClass({
+export default createReactClass({
   displayName: 'Header',
   propTypes: {
-    label:          React.PropTypes.string.isRequired,
-    labelId:        React.PropTypes.string,
+    label:          PropTypes.string.isRequired,
+    labelId:        PropTypes.string,
 
-    upDisabled:     React.PropTypes.bool.isRequired,
-    prevDisabled:   React.PropTypes.bool.isRequired,
-    nextDisabled:   React.PropTypes.bool.isRequired,
-    onViewChange:   React.PropTypes.func.isRequired,
-    onMoveLeft:     React.PropTypes.func.isRequired,
-    onMoveRight:    React.PropTypes.func.isRequired,
+    upDisabled:     PropTypes.bool.isRequired,
+    prevDisabled:   PropTypes.bool.isRequired,
+    nextDisabled:   PropTypes.bool.isRequired,
+    onViewChange:   PropTypes.func.isRequired,
+    onMoveLeft:     PropTypes.func.isRequired,
+    onMoveRight:    PropTypes.func.isRequired,
 
-    messages:       React.PropTypes.shape({
-      moveBack:     React.PropTypes.string,
-      moveForward:  React.PropTypes.string
+    messages:       PropTypes.shape({
+      moveBack:     PropTypes.string,
+      moveForward:  PropTypes.string
     })
   },
 
@@ -71,4 +73,4 @@ export default React.createClass({
       </div>
     )
   }
-})
+});

--- a/src/List.jsx
+++ b/src/List.jsx
@@ -1,4 +1,6 @@
+import PropTypes from 'prop-types';
 import React   from 'react';
+import createReactClass from 'create-react-class';
 import ListOption from './ListOption';
 import CustomPropTypes from './util/propTypes';
 import compat from './util/compat';
@@ -10,7 +12,7 @@ import { isDisabledItem, isReadOnlyItem }  from './util/interaction';
 
 let optionId = (id, idx)=> `${id}__option__${idx}`;
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'List',
 
@@ -20,22 +22,22 @@ export default React.createClass({
   ],
 
   propTypes: {
-    data:          React.PropTypes.array,
-    onSelect:      React.PropTypes.func,
-    onMove:        React.PropTypes.func,
+    data:          PropTypes.array,
+    onSelect:      PropTypes.func,
+    onMove:        PropTypes.func,
 
     optionComponent: CustomPropTypes.elementType,
     itemComponent:   CustomPropTypes.elementType,
 
-    selected:      React.PropTypes.any,
-    focused:       React.PropTypes.any,
+    selected:      PropTypes.any,
+    focused:       PropTypes.any,
     valueField:    CustomPropTypes.accessor,
     textField:     CustomPropTypes.accessor,
 
     disabled:      CustomPropTypes.disabled.acceptsArray,
     readOnly:      CustomPropTypes.readOnly.acceptsArray,
 
-    messages:      React.PropTypes.shape({
+    messages:      PropTypes.shape({
       emptyList:   CustomPropTypes.message
     })
   },
@@ -141,4 +143,4 @@ export default React.createClass({
     notify(this.props.onMove, [ selected, list, this.props.focused ])
   }
 
-})
+});

--- a/src/ListGroupable.jsx
+++ b/src/ListGroupable.jsx
@@ -1,4 +1,6 @@
+import PropTypes from 'prop-types';
 import React   from 'react';
+import createReactClass from 'create-react-class';
 import ListOption from './ListOption';
 import CustomPropTypes from './util/propTypes';
 import compat from './util/compat';
@@ -11,7 +13,7 @@ import { isDisabledItem, isReadOnlyItem }  from './util/interaction';
 
 let optionId = (id, idx)=> `${id}__option__${idx}`;
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'List',
 
@@ -21,16 +23,16 @@ export default React.createClass({
   ],
 
   propTypes: {
-    data:           React.PropTypes.array,
-    onSelect:       React.PropTypes.func,
-    onMove:         React.PropTypes.func,
+    data:           PropTypes.array,
+    onSelect:       PropTypes.func,
+    onMove:         PropTypes.func,
 
     optionComponent: CustomPropTypes.elementType,
     itemComponent:   CustomPropTypes.elementType,
     groupComponent:  CustomPropTypes.elementType,
 
-    selected:       React.PropTypes.any,
-    focused:        React.PropTypes.any,
+    selected:       PropTypes.any,
+    focused:        PropTypes.any,
 
     valueField:     CustomPropTypes.accessor,
     textField:      CustomPropTypes.accessor,
@@ -40,7 +42,7 @@ export default React.createClass({
 
     groupBy:        CustomPropTypes.accessor,
 
-    messages:       React.PropTypes.shape({
+    messages:       PropTypes.shape({
       emptyList:    CustomPropTypes.message
     })
   },
@@ -248,4 +250,4 @@ export default React.createClass({
     return child
   }
 
-})
+});

--- a/src/ListOption.jsx
+++ b/src/ListOption.jsx
@@ -1,15 +1,16 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import cn from 'classnames';
 import _  from './util/_';
 
-let ListOption = React.createClass({
-  propTypes: {
-    dataItem: React.PropTypes.any,
-    focused:  React.PropTypes.bool,
-    selected: React.PropTypes.bool,
-    disabled: React.PropTypes.bool,
-    readOnly: React.PropTypes.bool
-  },
+class ListOption extends React.Component {
+  static propTypes = {
+    dataItem: PropTypes.any,
+    focused:  PropTypes.bool,
+    selected: PropTypes.bool,
+    disabled: PropTypes.bool,
+    readOnly: PropTypes.bool
+  };
 
   render() {
     let { className, children, focused, selected, disabled, readOnly } = this.props;
@@ -35,6 +36,6 @@ let ListOption = React.createClass({
       </li>
     );
   }
-});
+}
 
 export default ListOption;

--- a/src/Month.jsx
+++ b/src/Month.jsx
@@ -1,4 +1,6 @@
+import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import CalendarView from './CalendarView';
 import dates from './util/dates';
 import { date as dateLocalizer } from './util/localizers';
@@ -12,13 +14,13 @@ let dayFormat = props => dateLocalizer.getFormat('weekday', props.dayFormat)
 let optionId = (id, date) => `${id}__month_${dates.month(date)}-${dates.date(date)}`;
 
 let propTypes = {
-  culture: React.PropTypes.string,
-  today: React.PropTypes.instanceOf(Date),
-  value: React.PropTypes.instanceOf(Date),
-  focused: React.PropTypes.instanceOf(Date),
-  min: React.PropTypes.instanceOf(Date),
-  max: React.PropTypes.instanceOf(Date),
-  onChange: React.PropTypes.func.isRequired,
+  culture: PropTypes.string,
+  today: PropTypes.instanceOf(Date),
+  value: PropTypes.instanceOf(Date),
+  focused: PropTypes.instanceOf(Date),
+  min: PropTypes.instanceOf(Date),
+  max: PropTypes.instanceOf(Date),
+  onChange: PropTypes.func.isRequired,
 
   dayComponent: CustomPropTypes.elementType,
   dayFormat: CustomPropTypes.dateFormat,
@@ -27,7 +29,7 @@ let propTypes = {
 
 let isEqual = (dateA, dateB) => dates.eq(dateA, dateB, 'day')
 
-let MonthView = React.createClass({
+let MonthView = createReactClass({
 
   displayName: 'MonthView',
 

--- a/src/Multiselect.jsx
+++ b/src/Multiselect.jsx
@@ -1,4 +1,6 @@
+import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cn from 'classnames';
 import _  from './util/_';
 import createUncontrolledWidget from 'uncontrollable';
@@ -25,19 +27,19 @@ let { splat } = _;
 var propTypes = {
   ...Popup.propTypes,
 
-  data:            React.PropTypes.array,
+  data:            PropTypes.array,
   //-- controlled props --
-  value:           React.PropTypes.array,
-  onChange:        React.PropTypes.func,
+  value:           PropTypes.array,
+  onChange:        PropTypes.func,
 
-  searchTerm:      React.PropTypes.string,
-  onSearch:        React.PropTypes.func,
+  searchTerm:      PropTypes.string,
+  onSearch:        PropTypes.func,
 
-  open:            React.PropTypes.bool,
-  onToggle:        React.PropTypes.func,
+  open:            PropTypes.bool,
+  onToggle:        PropTypes.func,
   //-------------------------------------------
 
-  valueField:      React.PropTypes.string,
+  valueField:      PropTypes.string,
   textField:       CustomPropTypes.accessor,
 
   tagComponent:    CustomPropTypes.elementType,
@@ -49,24 +51,24 @@ var propTypes = {
 
   createComponent: CustomPropTypes.elementType,
 
-  onSelect:        React.PropTypes.func,
-  onCreate:        React.PropTypes.oneOfType([
-                     React.PropTypes.oneOf([false]),
-                     React.PropTypes.func
+  onSelect:        PropTypes.func,
+  onCreate:        PropTypes.oneOfType([
+                     PropTypes.oneOf([false]),
+                     PropTypes.func
                    ]),
 
-  inputSize:       React.PropTypes.func,
+  inputSize:       PropTypes.func,
 
-  busy:            React.PropTypes.bool,
-  dropUp:          React.PropTypes.bool,
+  busy:            PropTypes.bool,
+  dropUp:          PropTypes.bool,
 
-  placeholder:     React.PropTypes.string,
+  placeholder:     PropTypes.string,
 
-  autoFocus:      React.PropTypes.bool,
+  autoFocus:      PropTypes.bool,
   disabled:       CustomPropTypes.disabled.acceptsArray,
   readOnly:       CustomPropTypes.readOnly.acceptsArray,
 
-  messages:        React.PropTypes.shape({
+  messages:        PropTypes.shape({
     open:          CustomPropTypes.message,
     emptyList:     CustomPropTypes.message,
     emptyFilter:   CustomPropTypes.message,
@@ -74,7 +76,7 @@ var propTypes = {
   })
 };
 
-var Multiselect = React.createClass({
+var Multiselect = createReactClass({
 
   displayName: 'Multiselect',
 
@@ -91,18 +93,18 @@ var Multiselect = React.createClass({
         if (!focused) this.close()
 
         if (!focused && this.refs.tagList)
-          this.setState({ focusedTag: null })
+          this.setState({focusedTag: null})
 
         if (focused && !this.props.open)
           this.open()
       }
     }),
-    require('./mixins/AriaDescendantMixin')('input', function(key, id){
-      let { ariaActiveDescendantKey: myKey } = this.props;
+    require('./mixins/AriaDescendantMixin')('input', function (key, id) {
+      let {ariaActiveDescendantKey: myKey} = this.props;
 
       let createIsActive =
-            (!this._data().length || this.state.focusedItem === null)
-            && key === myKey;
+          (!this._data().length || this.state.focusedItem === null)
+          && key === myKey;
 
       let tagIsActive = this.state.focusedTag != null && key === 'taglist';
       let listIsActive = this.state.focusedTag == null && key === 'list';
@@ -123,194 +125,195 @@ var Multiselect = React.createClass({
       searchTerm: '',
       ariaActiveDescendantKey: 'multiselect',
       messages: {
-        createNew:     '(create new tag)',
-        emptyList:     'There are no items in this list',
-        emptyFilter:   'The filter returned no results',
-        tagsLabel:     'selected items',
+        createNew: '(create new tag)',
+        emptyList: 'There are no items in this list',
+        emptyFilter: 'The filter returned no results',
+        tagsLabel: 'selected items',
         selectedItems: 'selected items',
-        noneSelected:  'no selected items',
-        removeLabel:   'remove selected item'
+        noneSelected: 'no selected items',
+        removeLabel: 'remove selected item'
       }
     }
   },
 
-  getInitialState(){
-    var { data, value, valueField, searchTerm } = this.props
-      , dataItems = splat(value).map( item => dataItem(data, item, valueField))
-      , processedData = this.process(data, dataItems, searchTerm)
+  getInitialState() {
+    var {data, value, valueField, searchTerm} = this.props
+        , dataItems = splat(value).map(item => dataItem(data, item, valueField))
+        , processedData = this.process(data, dataItems, searchTerm)
 
     return {
-      focusedTag:    null,
-      focusedItem:   processedData[0],
+      focusedTag: null,
+      focusedItem: processedData[0],
       processedData: processedData,
-      dataItems:     dataItems
+      dataItems: dataItems
     }
   },
 
   componentDidUpdate() {
     this.ariaActiveDescendant(
-      instanceId(this, '__createlist_option'))
+        instanceId(this, '__createlist_option'))
 
     this.refs.list && validateList(this.refs.list)
   },
 
   componentWillReceiveProps(nextProps) {
-    var { data, value, valueField, searchTerm } = nextProps
-      , values = _.splat(value)
-      , current = this.state.focusedItem
-      , items  = this.process(data, values, searchTerm)
+    var {data, value, valueField, searchTerm} = nextProps
+        , values = _.splat(value)
+        , current = this.state.focusedItem
+        , items = this.process(data, values, searchTerm)
 
     this.setState({
       processedData: items,
       focusedItem: items.indexOf(current) === -1 ? items[0] : current,
-      dataItems: values.map( item => dataItem(data, item, valueField))
+      dataItems: values.map(item => dataItem(data, item, valueField))
     })
   },
 
   renderCreateItem(id, messages) {
-    let { searchTerm } = this.props;
-    let { focusedItem } = this.state;
+    let {searchTerm} = this.props;
+    let {focusedItem} = this.state;
 
     let createIsFocused = !this._data().length || focusedItem === null;
     let optionID = instanceId(this, '__createlist_option');
 
     return (
-      <ul
-        id={id}
-        role='listbox'
-        className="rw-list rw-multiselect-create-tag"
-      >
-        <li
-          id={optionID}
-          role='option'
-          onClick={() => this.handleCreate(searchTerm)}
-          className={cn(
-            'rw-list-option',
-            'rw-create-list-option',
-            createIsFocused && 'rw-state-focus'
-          )}
+        <ul
+            id={id}
+            role='listbox'
+            className="rw-list rw-multiselect-create-tag"
         >
-          {compatCreate(this.props, messages)}
-        </li>
-      </ul>
+          <li
+              id={optionID}
+              role='option'
+              onClick={() => this.handleCreate(searchTerm)}
+              className={cn(
+                  'rw-list-option',
+                  'rw-create-list-option',
+                  createIsFocused && 'rw-state-focus'
+              )}
+          >
+            {compatCreate(this.props, messages)}
+          </li>
+        </ul>
     )
   },
 
   renderInput(owns) {
     let {
-        searchTerm
+      searchTerm
       , maxLength
       , tabIndex
       , busy
       , open
       , disabled
-      , readOnly } = this.props;
+      , readOnly
+    } = this.props;
 
     return (
-      <SelectInput
-        ref='input'
-        tabIndex={tabIndex || 0}
-        role='listbox'
-        aria-expanded={!!open}
-        aria-busy={!!busy}
-        autoFocus={this.props.autoFocus}
-        aria-owns={owns}
-        aria-haspopup={true}
-        value={searchTerm}
-        maxLength={maxLength}
-        disabled={disabled === true}
-        readOnly={readOnly === true}
-        placeholder={this.getPlaceholder()}
-        inputSize={this.props.inputSize}
-        onKeyDown={this.handleSearchKeyDown}
-        onKeyUp={this.handleSearchKeyUp}
-        onChange={this.handleInputChange}
-        onClick={this.handleInputInteraction}
-        onTouchEnd={this.handleInputInteraction}
-      />
+        <SelectInput
+            ref='input'
+            tabIndex={tabIndex || 0}
+            role='listbox'
+            aria-expanded={!!open}
+            aria-busy={!!busy}
+            autoFocus={this.props.autoFocus}
+            aria-owns={owns}
+            aria-haspopup={true}
+            value={searchTerm}
+            maxLength={maxLength}
+            disabled={disabled === true}
+            readOnly={readOnly === true}
+            placeholder={this.getPlaceholder()}
+            inputSize={this.props.inputSize}
+            onKeyDown={this.handleSearchKeyDown}
+            onKeyUp={this.handleSearchKeyUp}
+            onChange={this.handleInputChange}
+            onClick={this.handleInputInteraction}
+            onTouchEnd={this.handleInputInteraction}
+        />
     )
   },
 
   renderList(List, id, messages) {
-    let { open, disabled, readOnly } = this.props;
-    let { focusedItem } = this.state;
+    let {open, disabled, readOnly} = this.props;
+    let {focusedItem} = this.state;
 
     let listProps = _.pickProps(this.props, List);
-    let items  = this._data();
+    let items = this._data();
 
     return (
-      <List ref="list"
-        key={0}
-        {...listProps}
-        readOnly={readOnly}
-        disabled={disabled}
-        id={id}
-        aria-live='polite'
-        aria-labelledby={instanceId(this)}
-        aria-hidden={!open}
-        ariaActiveDescendantKey='list'
-        data={items}
-        focused={focusedItem}
-        onSelect={this.handleSelect}
-        onMove={this._scrollTo}
-        messages={{
-          emptyList: this._lengthWithoutValues
-            ? messages.emptyFilter
-            : messages.emptyList
-        }}
-      />
+        <List ref="list"
+              key={0}
+              {...listProps}
+              readOnly={readOnly}
+              disabled={disabled}
+              id={id}
+              aria-live='polite'
+              aria-labelledby={instanceId(this)}
+              aria-hidden={!open}
+              ariaActiveDescendantKey='list'
+              data={items}
+              focused={focusedItem}
+              onSelect={this.handleSelect}
+              onMove={this._scrollTo}
+              messages={{
+                emptyList: this._lengthWithoutValues
+                    ? messages.emptyFilter
+                    : messages.emptyList
+              }}
+        />
     )
   },
 
   renderNotificationArea(id, messages) {
-    let { textField } = this.props;
-    let { focused, dataItems } = this.state;
+    let {textField} = this.props;
+    let {focused, dataItems} = this.state;
 
     return (
-      <span
-        id={id}
-        role="status"
-        className='rw-sr'
-        aria-live='assertive'
-        aria-atomic="true"
-        aria-relevant="additions removals text"
-      >
+        <span
+            id={id}
+            role="status"
+            className='rw-sr'
+            aria-live='assertive'
+            aria-atomic="true"
+            aria-relevant="additions removals text"
+        >
         {focused && (
-          dataItems.length
-            ? (messages.selectedItems + ': ' + dataItems.map(item => dataText(item, textField)).join(', '))
-            : messages.noneSelected
+            dataItems.length
+                ? (messages.selectedItems + ': ' + dataItems.map(item => dataText(item, textField)).join(', '))
+                : messages.noneSelected
         )}
       </span>
     )
   },
 
   renderTags(id, messages) {
-    let { disabled, readOnly, valueField, textField } = this.props;
-    let { focusedTag, dataItems } = this.state;
+    let {disabled, readOnly, valueField, textField} = this.props;
+    let {focusedTag, dataItems} = this.state;
 
     let Component = this.props.tagComponent;
 
     return (
-      <TagList
-        ref='tagList'
-        id={id}
-        valueField={valueField}
-        textField={textField}
-        aria-label={messages.tagsLabel}
-        value={dataItems}
-        focused={focusedTag}
-        disabled={disabled}
-        readOnly={readOnly}
-        onDelete={this.handleDelete}
-        valueComponent={Component}
-        ariaActiveDescendantKey='taglist'
-      />
+        <TagList
+            ref='tagList'
+            id={id}
+            valueField={valueField}
+            textField={textField}
+            aria-label={messages.tagsLabel}
+            value={dataItems}
+            focused={focusedTag}
+            disabled={disabled}
+            readOnly={readOnly}
+            onDelete={this.handleDelete}
+            valueComponent={Component}
+            ariaActiveDescendantKey='taglist'
+        />
     )
   },
 
   render() {
     let {
-        className
+      className
       , groupBy
       , messages
       , busy
@@ -319,72 +322,73 @@ var Multiselect = React.createClass({
       , duration
       , disabled
       , readOnly
-      , listComponent: List } = this.props;
+      , listComponent: List
+    } = this.props;
 
-    let { focused, dataItems } = this.state;
+    let {focused, dataItems} = this.state;
 
     List = List || (groupBy && GroupableList) || PlainList
 
     let elementProps = _.omitOwnProps(this, List);
 
     let shouldRenderTags = !!dataItems.length
-      , shouldRenderPopup = isFirstFocusedRender(this) || open
-      , shouldShowCreate = this.shouldShowCreate();
+        , shouldRenderPopup = isFirstFocusedRender(this) || open
+        , shouldShowCreate = this.shouldShowCreate();
 
     let tagsID = instanceId(this, '_taglist')
-      , listID = instanceId(this, '__listbox')
-      , createID = instanceId(this, '__createlist')
-      , notifyID = instanceId(this, '__notify');
+        , listID = instanceId(this, '__listbox')
+        , createID = instanceId(this, '__createlist')
+        , notifyID = instanceId(this, '__notify');
 
     let inputOwns = `${listID} ${notifyID} `
-      + (shouldRenderTags ? tagsID : '')
-      + (shouldShowCreate ? createID : '');
+        + (shouldRenderTags ? tagsID : '')
+        + (shouldShowCreate ? createID : '');
 
     messages = msgs(messages);
 
     return (
-      <Widget
-        {...elementProps}
-        id={instanceId(this)}
-        open={open}
-        dropUp={dropUp}
-        focused={focused}
-        disabled={disabled === true}
-        readOnly={readOnly === true}
-        onKeyDown={this.handleKeyDown}
-        onBlur={this.handleBlur}
-        onFocus={this.handleFocus}
-        onTouchEnd={this.handleFocus}
-        className={cn(className, 'rw-multiselect')}
-      >
-        {this.renderNotificationArea(notifyID, messages)}
-
-        <div className='rw-multiselect-wrapper'>
-          {busy && <span className="rw-i rw-loading" />}
-
-          {shouldRenderTags &&
-            this.renderTags(tagsID, messages)
-          }
-
-          {this.renderInput(inputOwns)}
-        </div>
-        {shouldRenderPopup &&
-          <Popup
-            dropUp={dropUp}
+        <Widget
+            {...elementProps}
+            id={instanceId(this)}
             open={open}
-            duration={duration}
-            onOpening={()=> this.refs.list.forceUpdate()}
+            dropUp={dropUp}
+            focused={focused}
+            disabled={disabled === true}
+            readOnly={readOnly === true}
+            onKeyDown={this.handleKeyDown}
+            onBlur={this.handleBlur}
+            onFocus={this.handleFocus}
+            onTouchEnd={this.handleFocus}
+            className={cn(className, 'rw-multiselect')}
+        >
+          {this.renderNotificationArea(notifyID, messages)}
+
+          <div className='rw-multiselect-wrapper'>
+            {busy && <span className="rw-i rw-loading"/>}
+
+            {shouldRenderTags &&
+            this.renderTags(tagsID, messages)
+            }
+
+            {this.renderInput(inputOwns)}
+          </div>
+          {shouldRenderPopup &&
+          <Popup
+              dropUp={dropUp}
+              open={open}
+              duration={duration}
+              onOpening={() => this.refs.list.forceUpdate()}
           >
             <div>
               {this.renderList(List, listID, messages)}
 
               {shouldShowCreate &&
-                this.renderCreateItem(createID, messages)
+              this.renderCreateItem(createID, messages)
               }
             </div>
           </Popup>
-        }
-      </Widget>
+          }
+        </Widget>
     )
   },
 
@@ -395,7 +399,7 @@ var Multiselect = React.createClass({
   handleDelete(value) {
     this.focus()
     this.change(
-      this.state.dataItems.filter( d => d !== value))
+        this.state.dataItems.filter(d => d !== value))
   },
 
   handleSearchKeyDown(e) {
@@ -409,169 +413,14 @@ var Multiselect = React.createClass({
   },
 
   handleInputChange(e) {
-    notify(this.props.onSearch, [ e.target.value ])
+    notify(this.props.onSearch, [e.target.value])
     this.open()
   },
 
   @widgetEditable
   handleInputInteraction() {
     this.open()
-  },
-
-  @widgetEditable
-  handleSelect(data) {
-    if (data === undefined) {
-      if (this.props.onCreate)
-        this.handleCreate(this.props.searchTerm)
-
-      return
-    }
-    notify(this.props.onSelect, data)
-    this.change(this.state.dataItems.concat(data))
-
-    this.close()
-    this.focus()
-  },
-
-  @widgetEditable
-  handleCreate(tag) {
-    if (tag.trim() === '' )
-      return
-
-    notify(this.props.onCreate, tag)
-    this.props.searchTerm
-      && notify(this.props.onSearch, [ '' ])
-
-    this.close()
-    this.focus()
-  },
-
-  @widgetEditable
-  handleKeyDown(e) {
-    let { key, keyCode, altKey, ctrlKey } = e
-      , noSearch = !this.props.searchTerm && !this._deletingText
-      , isOpen  = this.props.open;
-
-    let { focusedTag, focusedItem } = this.state;
-    let { list, tagList } = this.refs;
-    let nullTag = { focusedTag: null };
-
-    notify(this.props.onKeyDown, [e])
-
-    if (e.defaultPrevented)
-      return
-
-    if ( key === 'ArrowDown') {
-      var next = list.next(focusedItem)
-        , creating = (this.shouldShowCreate() && focusedItem === next) || focusedItem === null;
-
-      next = creating ? null : next
-
-      e.preventDefault()
-      if (isOpen) this.setState({ focusedItem: next, ...nullTag })
-      else        this.open()
-    }
-    else if (key === 'ArrowUp') {
-      var prev = focusedItem === null
-        ? list.last()
-        : list.prev(focusedItem)
-
-      e.preventDefault()
-
-      if (altKey)      this.close()
-      else if (isOpen) this.setState({ focusedItem: prev, ...nullTag })
-    }
-    else if (key === 'End') {
-      e.preventDefault()
-      if ( isOpen ) this.setState({ focusedItem: list.last(), ...nullTag })
-      else          tagList && this.setState({ focusedTag: tagList.last() })
-    }
-    else if (key === 'Home') {
-      e.preventDefault()
-      if (isOpen) this.setState({ focusedItem: list.first(), ...nullTag })
-      else          tagList && this.setState({ focusedTag: tagList.first() })
-    }
-    else if (isOpen && keyCode === 13) { // using keyCode to ignore enter for japanese IME
-      e.preventDefault();
-      (ctrlKey && this.props.onCreate) || focusedItem === null
-        ? this.handleCreate(this.props.searchTerm)
-        : this.handleSelect(this.state.focusedItem)
-    }
-    else if (key === 'Escape')
-      isOpen ? this.close() : tagList && this.setState(nullTag)
-
-    else if (noSearch && key === 'ArrowLeft')
-      tagList && this.setState({ focusedTag: tagList.prev(focusedTag) })
-
-    else if (noSearch && key === 'ArrowRight')
-      tagList && this.setState({ focusedTag: tagList.next(focusedTag) })
-
-    else if (noSearch && key === 'Delete')
-      tagList && tagList.remove(focusedTag)
-
-    else if (noSearch && key === 'Backspace')
-      tagList && tagList.removeNext()
-
-  },
-
-  @widgetEditable
-  change(data) {
-    notify(this.props.onChange, [data])
-    notify(this.props.onSearch, [ '' ])
-  },
-
-  focus() {
-    this.refs.input &&
-      this.refs.input.focus()
-  },
-
-  open() {
-    if (!this.props.open)
-      notify(this.props.onToggle, true)
-  },
-
-  close() {
-    notify(this.props.onToggle, false)
-  },
-
-  toggle() {
-    this.props.open
-      ? this.close()
-      : this.open()
-  },
-
-  process(data, values, searchTerm) {
-    var { valueField } = this.props;
-    var items = data.filter( i =>
-      !values.some(v => valueMatcher(i, v, valueField)))
-
-    this._lengthWithoutValues = items.length;
-
-    if (searchTerm)
-      items = this.filter(items, searchTerm)
-
-    return items
-  },
-
-  shouldShowCreate() {
-    var { textField, searchTerm, onCreate, caseSensitive } = this.props;
-
-    if ( !onCreate || !searchTerm )
-      return false
-
-    var lower = text => caseSensitive ? text : text.toLowerCase();
-    var eq =  v => lower(dataText(v, textField)) === lower(searchTerm);
-
-    // if there is an exact match on textFields: "john" => { name: "john" }, don't show
-    return !this._data().some(eq) && !this.state.dataItems.some(eq)
-  },
-
-  getPlaceholder() {
-    return (this.props.value || []).length
-      ? ''
-      : (this.props.placeholder || '')
   }
-
 })
 
 function msgs(msgs){

--- a/src/MultiselectInput.jsx
+++ b/src/MultiselectInput.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _  from './util/_';
 import compat from './util/compat';
@@ -6,11 +7,11 @@ import CustomPropTypes from './util/propTypes';
 class MultiselectInput extends React.Component {
 
   static propTypes = {
-    value:        React.PropTypes.string,
-    placeholder:  React.PropTypes.string,
-    maxLength:    React.PropTypes.number,
-    inputSize:    React.PropTypes.func,
-    onChange:     React.PropTypes.func.isRequired,
+    value:        PropTypes.string,
+    placeholder:  PropTypes.string,
+    maxLength:    PropTypes.number,
+    inputSize:    PropTypes.func,
+    onChange:     PropTypes.func.isRequired,
 
     disabled:     CustomPropTypes.disabled,
     readOnly:     CustomPropTypes.readOnly

--- a/src/MultiselectTagList.jsx
+++ b/src/MultiselectTagList.jsx
@@ -1,4 +1,6 @@
+import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import _  from './util/_';
 import cx from 'classnames';
 import CustomPropTypes from './util/propTypes';
@@ -9,7 +11,8 @@ import { isDisabled, isDisabledItem, isReadOnlyItem } from './util/interaction';
 
 let optionId = (id, idx)=> `${id}__option__${idx}`;
 
-export default React.createClass({
+export default createReactClass({
+  displayName: 'MultiselectTagList',
 
   mixins: [
     require('./mixins/PureRenderMixin'),
@@ -17,14 +20,14 @@ export default React.createClass({
   ],
 
   propTypes: {
-    value:          React.PropTypes.array,
-    focused:        React.PropTypes.number,
+    value:          PropTypes.array,
+    focused:        PropTypes.number,
 
-    valueField:     React.PropTypes.string,
+    valueField:     PropTypes.string,
     textField:      CustomPropTypes.accessor,
 
-    onDelete:       React.PropTypes.func.isRequired,
-    valueComponent: React.PropTypes.func,
+    onDelete:       PropTypes.func.isRequired,
+    valueComponent: PropTypes.func,
 
     disabled:       CustomPropTypes.disabled.acceptsArray,
     readOnly:       CustomPropTypes.readOnly.acceptsArray
@@ -114,7 +117,6 @@ export default React.createClass({
       this.props.onDelete(val)
   },
 
-
   clear(){
     this.setState({ focused: null })
   },
@@ -167,5 +169,5 @@ export default React.createClass({
       nextIdx--
 
     return nextIdx >= 0 ? nextIdx : null;
-  }
+  },
 });

--- a/src/NumberInput.jsx
+++ b/src/NumberInput.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import _  from './util/_';
 import CustomPropTypes from './util/propTypes';
@@ -6,35 +7,31 @@ import { number as numberLocalizer } from './util/localizers';
 let getFormat = props => numberLocalizer.getFormat('default', props.format)
 
 let propTypes = {
-  value:       React.PropTypes.number,
-  editing:     React.PropTypes.bool,
-  placeholder: React.PropTypes.string,
+  value:       PropTypes.number,
+  editing:     PropTypes.bool,
+  placeholder: PropTypes.string,
 
   format:      CustomPropTypes.numberFormat,
 
-  parse:       React.PropTypes.func,
-  culture:     React.PropTypes.string,
+  parse:       PropTypes.func,
+  culture:     PropTypes.string,
 
-  min:         React.PropTypes.number,
+  min:         PropTypes.number,
 
-  onChange:    React.PropTypes.func.isRequired,
-  onKeyDown:   React.PropTypes.func
+  onChange:    PropTypes.func.isRequired,
+  onKeyDown:   PropTypes.func
 };
 
-export default React.createClass({
+export default class extends React.Component {
+  static displayName = 'NumberPickerInput';
+  static propTypes = propTypes;
 
-  displayName: 'NumberPickerInput',
+  static defaultProps = {
+    value: null,
+    editing: false
+  };
 
-  propTypes,
-
-  getDefaultProps() {
-    return {
-      value: null,
-      editing: false
-    }
-  },
-
-  getDefaultState(props = this.props){
+  getDefaultState = (props = this.props) => {
     var value = props.value
       , decimal = numberLocalizer.decimalChar(null, props.culture)
       , format = getFormat(props);
@@ -49,18 +46,14 @@ export default React.createClass({
     return {
       stringValue: '' + value
     }
-  },
-
-  getInitialState() {
-    return this.getDefaultState()
-  },
+  };
 
   componentWillReceiveProps(nextProps) {
     this.setState(
       this.getDefaultState(nextProps))
-  },
+  }
 
-  render(){
+  render() {
     let value = this.state.stringValue;
     let props = _.omitOwnProps(this);
 
@@ -79,9 +72,9 @@ export default React.createClass({
         value={value}
       />
     )
-  },
+  }
 
-  _change(e) {
+  _change = (e) => {
     var val = e.target.value
       , number = this._parse(e.target.value)
 
@@ -100,9 +93,9 @@ export default React.createClass({
     else {
       this.current(e.target.value)
     }
-  },
+  };
 
-  _finish() {
+  _finish = () => {
     var str = this.state.stringValue
       , number = this._parse(str);
 
@@ -114,9 +107,9 @@ export default React.createClass({
       }
       this.props.onChange(number)
     }
-  },
+  };
 
-  _parse(strVal) {
+  _parse = (strVal) => {
     let culture = this.props.culture
       , delimChar = numberLocalizer.decimalChar(null, culture)
       , userParse = this.props.parse;
@@ -128,22 +121,22 @@ export default React.createClass({
     strVal = parseFloat(strVal);
 
     return strVal
-  },
+  };
 
-  isIntermediateValue(num, str) {
+  isIntermediateValue = (num, str) => {
     return !!(
       num < this.props.min ||
       this.isSign(str) ||
       this.isAtDelimiter(num, str) ||
       this.isPaddedZeros(str)
     );
-  },
+  };
 
-  isSign(val) {
+  isSign = (val) => {
     return (val || '').trim() === '-';
-  },
+  };
 
-  isPaddedZeros(str) {
+  isPaddedZeros = (str) => {
     let localeChar = numberLocalizer.decimalChar(null, this.props.culture)
     let [_, decimals] = str.split(localeChar);
 
@@ -151,9 +144,9 @@ export default React.createClass({
       decimals &&
       decimals.match(/0+$/)
     )
-  },
+  };
 
-  isAtDelimiter(num, str, props = this.props) {
+  isAtDelimiter = (num, str, props = this.props) => {
     var localeChar = numberLocalizer.decimalChar(null, props.culture)
       , lastIndex = str.length - 1
       , char;
@@ -166,17 +159,18 @@ export default React.createClass({
       char === localeChar &&
       str.indexOf(char) === lastIndex
     )
-  },
+  };
 
-  isValid(num) {
+  isValid = (num) => {
     if (typeof num !== 'number' || isNaN(num))
       return false
     return num >= this.props.min
-  },
+  };
 
   //this intermediate state is for when one runs into the decimal or are typing the number
-  current(stringValue) {
+  current = (stringValue) => {
     this.setState({ stringValue })
-  }
+  };
 
-});
+  state = this.getDefaultState();
+}

--- a/src/NumberPicker.jsx
+++ b/src/NumberPicker.jsx
@@ -1,4 +1,6 @@
+import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx    from 'classnames';
 import _     from './util/_';
 import compat from './util/compat';
@@ -19,37 +21,37 @@ var format = props => numberLocalizer.getFormat('default', props.format)
 let propTypes = {
 
       // -- controlled props -----------
-      value:          React.PropTypes.number,
-      onChange:       React.PropTypes.func,
+      value:          PropTypes.number,
+      onChange:       PropTypes.func,
       //------------------------------------
 
-      min:            React.PropTypes.number,
-      max:            React.PropTypes.number,
-      step:           React.PropTypes.number,
+      min:            PropTypes.number,
+      max:            PropTypes.number,
+      step:           PropTypes.number,
 
-      precision:      React.PropTypes.number,
+      precision:      PropTypes.number,
 
-      culture:        React.PropTypes.string,
+      culture:        PropTypes.string,
 
       format:         CustomPropTypes.numberFormat,
 
-      name:           React.PropTypes.string,
+      name:           PropTypes.string,
 
-      parse:          React.PropTypes.func,
+      parse:          PropTypes.func,
 
-      autoFocus:      React.PropTypes.bool,
+      autoFocus:      PropTypes.bool,
       disabled:       CustomPropTypes.disabled,
       readOnly:       CustomPropTypes.readOnly,
 
-      messages:       React.PropTypes.shape({
-        increment:    React.PropTypes.string,
-        decrement:    React.PropTypes.string
+      messages:       PropTypes.shape({
+        increment:    PropTypes.string,
+        decrement:    PropTypes.string
       }),
 
-      placeholder: React.PropTypes.string
+      placeholder: PropTypes.string
     };
 
-let NumberPicker = React.createClass({
+let NumberPicker = createReactClass({
 
   displayName: 'NumberPicker',
 
@@ -253,7 +255,6 @@ let NumberPicker = React.createClass({
 
     return Math.max(Math.min(value, max), min)
   }
-
 })
 
 

--- a/src/Popup.jsx
+++ b/src/Popup.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { cloneElement } from 'react';
 import _ from './util/_';
 import css from 'dom-helpers/style';
@@ -30,45 +31,39 @@ let OVERFLOW = {
 }
 
 let propTypes = {
-  open:           React.PropTypes.bool,
-  dropUp:         React.PropTypes.bool,
-  duration:       React.PropTypes.number,
+  open:           PropTypes.bool,
+  dropUp:         PropTypes.bool,
+  duration:       PropTypes.number,
 
-  onClosing:      React.PropTypes.func,
-  onOpening:      React.PropTypes.func,
-  onClose:        React.PropTypes.func,
-  onOpen:         React.PropTypes.func
+  onClosing:      PropTypes.func,
+  onOpening:      PropTypes.func,
+  onClose:        PropTypes.func,
+  onOpen:         PropTypes.func
 }
 
-export default React.createClass({
+export default class extends React.Component {
+  static displayName = 'Popup';
+  static propTypes = propTypes;
 
-  displayName: 'Popup',
+  static defaultProps = {
+    duration:    200,
+    open:        false,
+    onClosing:   function(){},
+    onOpening:   function(){},
+    onClose:     function(){},
+    onOpen:      function(){}
+  };
 
-  propTypes,
-
-  getInitialState() {
-    return {
-      initialRender: true,
-      status: this.props.open ? OPENING : CLOSED
-    }
-  },
-
-  getDefaultProps(){
-    return {
-      duration:    200,
-      open:        false,
-      onClosing:   function(){},
-      onOpening:   function(){},
-      onClose:     function(){},
-      onOpen:      function(){}
-    }
-  },
+  state = {
+    initialRender: true,
+    status: this.props.open ? OPENING : CLOSED
+  };
 
   componentWillReceiveProps(nextProps) {
     this.setState({
       contentChanged: childKey(nextProps.children) !== childKey(this.props.children)
     })
-  },
+  }
 
   componentDidMount() {
     let isOpen = this.state.status === OPENING;
@@ -79,9 +74,9 @@ export default React.createClass({
         this.open();
       }
     })
-  },
+  }
 
-  componentDidUpdate(pvProps){
+  componentDidUpdate(pvProps) {
     var closing =  pvProps.open && !this.props.open
       , opening = !pvProps.open && this.props.open
       , open    = this.props.open
@@ -107,7 +102,7 @@ export default React.createClass({
       if (isNaN(diff) || diff > 0.1)
         this.setState({ height });
     }
-  },
+  }
 
   render() {
     var { className, dropUp, style } = this.props
@@ -133,9 +128,9 @@ export default React.createClass({
         { this.renderChildren() }
       </div>
     )
-  },
+  }
 
-  renderChildren() {
+  renderChildren = () => {
     if (!this.props.children)
       return <span className='rw-popup rw-widget' />
 
@@ -150,9 +145,9 @@ export default React.createClass({
       },
       className: cn(child.props.className, 'rw-popup rw-widget')
     });
-  },
+  };
 
-  open() {
+  open = () => {
     this.cancelNextCallback()
     var el = compat.findDOMNode(this).firstChild
       , height = this.height();
@@ -169,9 +164,9 @@ export default React.createClass({
         })
       })
     })
-  },
+  };
 
-  close() {
+  close = () => {
     this.cancelNextCallback()
     var el = compat.findDOMNode(this).firstChild
       , height = this.height();
@@ -188,9 +183,9 @@ export default React.createClass({
         })
       )
     })
-  },
+  };
 
-  getOffsetForStatus(status) {
+  getOffsetForStatus = (status) => {
     if (this.state.initialRender)
       return {}
 
@@ -202,9 +197,9 @@ export default React.createClass({
       [OPENING]: _in,
       [OPEN]: out
     }[status] || {}
-  },
+  };
 
-  height() {
+  height = () => {
     var container = compat.findDOMNode(this)
       , content = container.firstChild
       , margin = parseInt(css(content, 'margin-top'), 10)
@@ -217,19 +212,19 @@ export default React.createClass({
     height = (getHeight(content) || 0) + (isNaN(margin) ? 0 : margin)
     container.style.display = old
     return height
-  },
+  };
 
-  isTransitioning() {
+  isTransitioning = () => {
     return this.state.status === OPENING
         || this.state.status === CLOSED
-  },
+  };
 
-  animate(el, props, dur, easing, cb) {
+  animate = (el, props, dur, easing, cb) => {
     this._transition =
       config.animate(el, props, dur, easing, this.setNextCallback(cb))
-  },
+  };
 
-  cancelNextCallback() {
+  cancelNextCallback = () => {
     if (this._transition && this._transition.cancel) {
       this._transition.cancel()
       this._transition = null
@@ -238,13 +233,13 @@ export default React.createClass({
       this.nextCallback.cancel();
       this.nextCallback = null;
     }
-  },
+  };
 
-  safeSetState(nextState, callback) {
+  safeSetState = (nextState, callback) => {
     this.setState(nextState, this.setNextCallback(callback));
-  },
+  };
 
-  setNextCallback(callback) {
+  setNextCallback = (callback) => {
     let active = true;
 
     this.nextCallback = (event) => {
@@ -257,9 +252,8 @@ export default React.createClass({
 
     this.nextCallback.cancel = () => active = false;
     return this.nextCallback;
-  }
-
-})
+  };
+}
 
 
 function childKey(children){

--- a/src/ReplaceTransitionGroup.jsx
+++ b/src/ReplaceTransitionGroup.jsx
@@ -4,7 +4,10 @@
  * https://github.com/facebook/react/blob/master/src/addons/transitions/ReactTransitionGroup.js
  * relevent code is licensed accordingly
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
+import createReactClass from 'create-react-class';
 import css from 'dom-helpers/style';
 import height from 'dom-helpers/query/height';
 import width  from 'dom-helpers/query/width';
@@ -19,18 +22,18 @@ function key(child){
   return child && child.key
 }
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'ReplaceTransitionGroup',
 
   propTypes: {
-    component: React.PropTypes.oneOfType([
-      React.PropTypes.element,
-      React.PropTypes.string
+    component: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.string
     ]),
-    childFactory: React.PropTypes.func,
-    onAnimating: React.PropTypes.func,
-    onAnimate: React.PropTypes.func
+    childFactory: PropTypes.func,
+    onAnimating: PropTypes.func,
+    onAnimate: PropTypes.func
   },
 
   getDefaultProps() {

--- a/src/SelectList.jsx
+++ b/src/SelectList.jsx
@@ -1,4 +1,6 @@
+import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import _  from './util/_';
 import cn from 'classnames';
 import createUncontrolledWidget from 'uncontrollable';
@@ -23,32 +25,32 @@ let { find } = _;
 
 let propTypes = {
 
-    data:           React.PropTypes.array,
-    value:          React.PropTypes.oneOfType([
-                      React.PropTypes.any,
-                      React.PropTypes.array
+    data:           PropTypes.array,
+    value:          PropTypes.oneOfType([
+                      PropTypes.any,
+                      PropTypes.array
                     ]),
-    onChange:       React.PropTypes.func,
-    onMove:         React.PropTypes.func,
+    onChange:       PropTypes.func,
+    onMove:         PropTypes.func,
 
-    multiple:       React.PropTypes.bool,
+    multiple:       PropTypes.bool,
 
     itemComponent:  CustomPropTypes.elementType,
     listComponent:  CustomPropTypes.elementType,
 
-    valueField:     React.PropTypes.string,
+    valueField:     PropTypes.string,
     textField:      CustomPropTypes.accessor,
 
-    busy:           React.PropTypes.bool,
+    busy:           PropTypes.bool,
 
-    filter:         React.PropTypes.string,
-    delay:          React.PropTypes.number,
+    filter:         PropTypes.string,
+    delay:          PropTypes.number,
 
     disabled:       CustomPropTypes.disabled.acceptsArray,
     readOnly:       CustomPropTypes.readOnly.acceptsArray,
 
-    messages:       React.PropTypes.shape({
-      emptyList:    React.PropTypes.string
+    messages:       PropTypes.shape({
+      emptyList:    PropTypes.string
     })
   }
 
@@ -63,7 +65,7 @@ function getFirstValue(props) {
   return null
 }
 
-var SelectList = React.createClass({
+var SelectList = createReactClass({
 
   propTypes: propTypes,
 
@@ -343,7 +345,7 @@ var SelectList = React.createClass({
 
 function getListItem(parent){
 
-  return React.createClass({
+  return createReactClass({
 
     displayName: 'SelectItem',
 
@@ -393,10 +395,8 @@ function getListItem(parent){
           </label>
         </ListOption>
       );
-
-
     }
-  })
+  });
 }
 
 export default createUncontrolledWidget(

--- a/src/SlideTransition.jsx
+++ b/src/SlideTransition.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React  from 'react';
 import ReplaceTransitionGroup  from './ReplaceTransitionGroup';
 import compat from './util/compat';
@@ -6,14 +7,13 @@ import getWidth from 'dom-helpers/query/width';
 import config from './util/configuration';
 import _ from './util/_';
 
-var SlideChildGroup = React.createClass({
+class SlideChildGroup extends React.Component {
+  static propTypes = {
+    direction: PropTypes.oneOf(['left', 'right']),
+    duration:  PropTypes.number
+  };
 
-  propTypes: {
-    direction: React.PropTypes.oneOf(['left', 'right']),
-    duration:  React.PropTypes.number
-  },
-
-  componentWillEnter(done) {
+  componentWillEnter = (done) => {
     var node  = compat.findDOMNode(this)
       , width = getWidth(node)
       , direction = this.props.direction;
@@ -34,9 +34,9 @@ var SlideChildGroup = React.createClass({
         this.ORGINAL_POSITION = null
         done && done()
       })
-  },
+  };
 
-  componentWillLeave(done) {
+  componentWillLeave = (done) => {
     var node  = compat.findDOMNode(this)
       , width = getWidth(node)
       , direction = this.props.direction;
@@ -56,36 +56,33 @@ var SlideChildGroup = React.createClass({
         this.ORGINAL_POSITION = null
         done && done()
       })
-  },
+  };
 
   render() {
     return React.Children.only(this.props.children);
   }
-})
+}
 
 
-module.exports = React.createClass({
+module.exports = class extends React.Component {
+  static propTypes = {
+    direction: PropTypes.oneOf(['left', 'right']),
+    duration:  PropTypes.number
+  };
 
-  propTypes: {
-    direction: React.PropTypes.oneOf(['left', 'right']),
-    duration:  React.PropTypes.number
-  },
+  static defaultProps = {
+    direction: 'left',
+    duration: 250
+  };
 
-  getDefaultProps(){
-    return {
-      direction: 'left',
-      duration: 250
-    }
-  },
-
-  _wrapChild(child, ref) {
+  _wrapChild = (child, ref) => {
     return (
       <SlideChildGroup key={child.key} ref={ref}
         direction={this.props.direction}
         duration={this.props.duration}>
         {child}
       </SlideChildGroup>)
-  },
+  };
 
   render() {
     var { style, children } = this.props
@@ -108,4 +105,4 @@ module.exports = React.createClass({
       </ReplaceTransitionGroup>
     )
   }
-});
+};

--- a/src/TimeList.jsx
+++ b/src/TimeList.jsx
@@ -1,5 +1,7 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import dates from './util/dates';
 import List from './List';
 import { date as dateLocalizer } from './util/localizers';
@@ -8,24 +10,24 @@ import _ from './util/_';
 
 var format = props => dateLocalizer.getFormat('time', props.format)
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'TimeList',
 
   propTypes: {
-    value: React.PropTypes.instanceOf(Date),
-    step: React.PropTypes.number,
-    min: React.PropTypes.instanceOf(Date),
-    max: React.PropTypes.instanceOf(Date),
-    currentDate: React.PropTypes.instanceOf(Date),
-    offsetMinutes: React.PropTypes.number,
+    value: PropTypes.instanceOf(Date),
+    step: PropTypes.number,
+    min: PropTypes.instanceOf(Date),
+    max: PropTypes.instanceOf(Date),
+    currentDate: PropTypes.instanceOf(Date),
+    offsetMinutes: PropTypes.number,
 
     itemComponent: CustomPropTypes.elementType,
     format: CustomPropTypes.dateFormat,
-    onSelect: React.PropTypes.func,
-    preserveDate: React.PropTypes.bool,
-    culture: React.PropTypes.string,
-    delay: React.PropTypes.number
+    onSelect: PropTypes.func,
+    preserveDate: PropTypes.bool,
+    culture: PropTypes.string,
+    delay: PropTypes.number
   },
 
   mixins: [

--- a/src/Widget.jsx
+++ b/src/Widget.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import cn from 'classnames';
 
 class Widget extends React.Component {

--- a/src/Year.jsx
+++ b/src/Year.jsx
@@ -1,4 +1,7 @@
+import PropTypes from 'prop-types';
 import React from 'react';
+
+import createReactClass from 'create-react-class';
 
 import CalendarView from './CalendarView'
 import dates from './util/dates';
@@ -10,20 +13,20 @@ import { instanceId } from './util/widgetHelpers';
 var format = props => dateLocalizer.getFormat('month', props.monthFormat)
 
 let propTypes = {
-  culture:      React.PropTypes.string,
-  today:        React.PropTypes.instanceOf(Date),
-  value:        React.PropTypes.instanceOf(Date),
-  focused:      React.PropTypes.instanceOf(Date),
-  min:          React.PropTypes.instanceOf(Date),
-  max:          React.PropTypes.instanceOf(Date),
-  onChange:     React.PropTypes.func.isRequired,
+  culture:      PropTypes.string,
+  today:        PropTypes.instanceOf(Date),
+  value:        PropTypes.instanceOf(Date),
+  focused:      PropTypes.instanceOf(Date),
+  min:          PropTypes.instanceOf(Date),
+  max:          PropTypes.instanceOf(Date),
+  onChange:     PropTypes.func.isRequired,
 
   monthFormat:  CustomPropTypes.dateFormat
 };
 
 let optionId = (id, date) => `${id}__year_${dates.year(date)}-${dates.month(date)}`;
 
-let YearView = React.createClass({
+let YearView = createReactClass({
 
   displayName: 'YearView',
 

--- a/src/localizers/globalize.js
+++ b/src/localizers/globalize.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import configure from '../configure'
 
 function endOfDecade(date) {

--- a/src/mixins/AriaDescendantMixin.js
+++ b/src/mixins/AriaDescendantMixin.js
@@ -1,10 +1,11 @@
 'use strict';
+import PropTypes from 'prop-types';
 import React from 'react';
 import compat from '../util/compat'
 
-let shape = React.PropTypes.shape({
+let shape = PropTypes.shape({
   //setActive: React.PropTypes.func,
-  reconcile: React.PropTypes.func
+  reconcile: PropTypes.func
 });
 
 function defaultReconcile(key, id) {
@@ -30,7 +31,7 @@ export default function(nodeOrComponent, reconcileChildren = defaultReconcile){
 
   return {
     propTypes: {
-      ariaActiveDescendantKey: React.PropTypes.string.isRequired
+      ariaActiveDescendantKey: PropTypes.string.isRequired
     },
 
     contextTypes: {
@@ -68,5 +69,5 @@ export default function(nodeOrComponent, reconcileChildren = defaultReconcile){
         }
       })
     }
-  }
+  };
 }

--- a/src/mixins/AutoFocusMixin.js
+++ b/src/mixins/AutoFocusMixin.js
@@ -1,9 +1,10 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { findDOMNode } from 'react-dom';
 
 export default {
   propTypes: {
-    autoFocus: React.PropTypes.bool
+    autoFocus: PropTypes.bool
   },
 
   componentDidMount() {

--- a/src/mixins/DataFilterMixin.js
+++ b/src/mixins/DataFilterMixin.js
@@ -1,4 +1,5 @@
 'use strict';
+import PropTypes from 'prop-types';
 import React  from 'react';
 import filters from '../util/filter';
 import CustomPropTypes from '../util/propTypes';
@@ -9,11 +10,11 @@ var dflt = f => f === true ? 'startsWith' : f ? f : 'eq'
 module.exports = {
 
     propTypes: {
-      data:           React.PropTypes.array,
-      value:          React.PropTypes.any,
+      data:           PropTypes.array,
+      value:          PropTypes.any,
       filter:         CustomPropTypes.filter,
-      caseSensitive:  React.PropTypes.bool,
-      minLength:      React.PropTypes.number
+      caseSensitive:  PropTypes.bool,
+      minLength:      PropTypes.number
     },
 
     getDefaultProps(){

--- a/src/mixins/DataHelpersMixin.js
+++ b/src/mixins/DataHelpersMixin.js
@@ -1,4 +1,5 @@
 'use strict';
+import PropTypes from 'prop-types';
 import React from 'react';
 import warning from 'warning';
 import propTypes from '../util/propTypes';
@@ -7,7 +8,7 @@ import * as dataHelpers from '../util/dataHelpers';
 export default {
 
   propTypes: {
-    valueField: React.PropTypes.string,
+    valueField: PropTypes.string,
     textField:  propTypes.accessor
   },
 

--- a/src/mixins/RtlChildContextMixin.js
+++ b/src/mixins/RtlChildContextMixin.js
@@ -1,9 +1,10 @@
+import PropTypes from 'prop-types';
 import  React from 'react';
 
 export default {
 
   contextTypes: {
-    isRtl: React.PropTypes.bool
+    isRtl: PropTypes.bool
   },
 
   isRtl() {

--- a/src/mixins/RtlParentContextMixin.js
+++ b/src/mixins/RtlParentContextMixin.js
@@ -1,18 +1,19 @@
 'use strict';
+var PropTypes = require('prop-types');
 var React = require('react')
 
 module.exports = {
 
   propTypes: {
-    isRtl: React.PropTypes.bool
+    isRtl: PropTypes.bool
   },
 
   contextTypes: {
-    isRtl: React.PropTypes.bool
+    isRtl: PropTypes.bool
   },
 
   childContextTypes: {
-    isRtl: React.PropTypes.bool
+    isRtl: PropTypes.bool
   },
 
   getChildContext() {

--- a/src/util/localizers.js
+++ b/src/util/localizers.js
@@ -1,10 +1,11 @@
 import invariant from 'invariant';
 import { has } from './_';
+import PropTypes from 'prop-types';
 import React from 'react';
 
-const localePropType = React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.func
+const localePropType = PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func
       ])
 
 const REQUIRED_NUMBER_FORMATS = [ 'default' ];

--- a/src/util/propTypes.js
+++ b/src/util/propTypes.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import localizers from './localizers';
 import filters from'./filter';
 
@@ -41,20 +42,20 @@ module.exports = {
   disabled: getInteractionPropType('disabled'),
   readOnly: getInteractionPropType('readOnly'),
 
-  accessor:     React.PropTypes.oneOfType([
-                    React.PropTypes.string,
-                    React.PropTypes.func
+  accessor:     PropTypes.oneOfType([
+                    PropTypes.string,
+                    PropTypes.func
                   ]),
 
-  message:      React.PropTypes.oneOfType([
-                  React.PropTypes.node,
-                  React.PropTypes.string
+  message:      PropTypes.oneOfType([
+                  PropTypes.node,
+                  PropTypes.string
                 ]),
 
-  filter:       React.PropTypes.oneOfType([
-                  React.PropTypes.func,
-                  React.PropTypes.bool,
-                  React.PropTypes.oneOf(filterTypes)
+  filter:       PropTypes.oneOfType([
+                  PropTypes.func,
+                  PropTypes.bool,
+                  PropTypes.oneOf(filterTypes)
                 ])
 }
 


### PR DESCRIPTION
I updated to support React 16 by using `create-react-class` instead of manually converting to class components. I figured eventually (hopefully soon) getting rid of the dependency was better than spending time converting without a codemod.

Most (All?) of the /src changes are me replacing `React.PropTypes` with `prop-types` for the migration from 0.14/15 to React 16.

Changes in /dist and /lib can be ignored, since these contain generated code. 